### PR TITLE
@W-13743560 | Update Calculator Request Object

### DIFF
--- a/commerce/domain/shipping/cart/calculator/classes/ShippingCartCalculatorSample.cls
+++ b/commerce/domain/shipping/cart/calculator/classes/ShippingCartCalculatorSample.cls
@@ -5,7 +5,7 @@
 
 // This class must extend the CartExtension.ShippingCartCalculator class to be processed.
 public class ShippingCartCalculatorSample extends CartExtension.ShippingCartCalculator {
-  public virtual override void calculate(CartExtension.CartCalculationRequest request) {
+  public virtual override void calculate(CartExtension.CartCalculateCalculatorRequest request) {
     CartExtension.Cart cart = request.getCart();
     // Clean up CVO based on Shipping
     CartExtension.CartValidationOutputCollection cartValidationOutputCollection = cart.getCartValidationOutputs();

--- a/commerce/domain/shipping/cart/calculator/classes/ShippingCartCalculatorSampleTest.cls
+++ b/commerce/domain/shipping/cart/calculator/classes/ShippingCartCalculatorSampleTest.cls
@@ -14,7 +14,7 @@ global with sharing class ShippingCartCalculatorSampleTest {
 
         // Act
         Test.startTest();
-        CartExtension.CartCalculationRequest request = new CartExtension.CartCalculationRequest(cart);
+        CartExtension.CartCalculateCalculatorRequest request = new CartExtension.CartCalculateCalculatorRequest(cart);
         ShippingCartCalculatorSample calculator = new ShippingCartCalculatorSample();
         calculator.calculate(request);
         Test.stopTest();

--- a/commerce/domain/tax/cart/calculator/classes/TaxCartCalculatorSample.cls
+++ b/commerce/domain/tax/cart/calculator/classes/TaxCartCalculatorSample.cls
@@ -3,7 +3,7 @@
 // (DTO). For a tax calcular extension to be processed by the checkout flow, you must implement the
 // CartExtension.AbstractCartCalculator class.
 public class TaxCartCalculatorSample extends CartExtension.AbstractCartCalculator {
-  public virtual override void calculate(CartExtension.CartCalculationRequest request) {
+  public virtual override void calculate(CartExtension.CartCalculateCalculatorRequest request) {
     try {
       CartExtension.Cart cart = request.getCart();
       System.debug('In Tax Calculator');


### PR DESCRIPTION
**Overview**

The request object for calculators has been renamed to `CartCalculateCalculatorRequest`. There is still a constructor for this object with only `CartDto` as an input, which will create an `OptionalBuyerActionDetails`.