### PR TITLE
@W-13037169 | Add Sample CCA Orchestrator Utest

### DIFF
--- a/commerce/domain/orchestrators/classes/CartCalculateExecutorForUnitTest.cls
+++ b/commerce/domain/orchestrators/classes/CartCalculateExecutorForUnitTest.cls
@@ -1,0 +1,40 @@
+/**
+* @description Sample mock executor for unit testing a custom orchestrator within Cart Calculate API.
+*/
+global class CartCalculateExecutorForUnitTest extends CartExtension.CartCalculateExecutorMock {
+
+    /**
+     * @description All classes extending CartExtension.CartCalculateExecutorMock must have a default constructor defined
+     */
+    global CartCalculateExecutorForUnitTest() {}
+
+    global override void prices(CartExtension.CartCalculateCalculatorRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        cart.setName('CartRepriced');
+    }
+
+    global override void promotions(CartExtension.CartCalculateCalculatorRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        cart.setName(cart.getName() + ', PromotionsRecalculated');
+    }
+
+    global override void inventory(CartExtension.CartCalculateCalculatorRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        cart.setName(cart.getName() + ', InventoryChecked');
+    }
+
+    global override void shipping(CartExtension.CartCalculateCalculatorRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        cart.setName(cart.getName() + ', ShippingRecalculated');
+    }
+
+    global override void tax(CartExtension.CartCalculateCalculatorRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        cart.setName(cart.getName() + ', TaxesRecalculated');
+    }
+
+    global override void postShipping(CartExtension.CartCalculateCalculatorRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        cart.setName(cart.getName() + ', PostShippingCompleted');
+    }
+}

--- a/commerce/domain/orchestrators/classes/CartCalculateSampleUnitTest.cls
+++ b/commerce/domain/orchestrators/classes/CartCalculateSampleUnitTest.cls
@@ -187,4 +187,50 @@ public class CartCalculateSampleUnitTest {
         System.assert(cart.getName().contains('TaxesRecalculated'));
         System.assert(cart.getName().contains('PostShippingCompleted'));
     }
+
+    @IsTest
+    public static void shouldRunPromotionsWhenBuyerAddsCoupon() {
+        // Arrange
+        // Create a cart
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        // Set up BuyerActions as if the Buyer added a coupon
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock();
+        buyerActions.setCouponChanged(true);
+
+        // Set up BuyerActionDetails as if the Buyer added a coupon
+        final boolean isCheckoutStarted = false;
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails(
+            isCheckoutStarted,
+            new List<CartExtension.CartDeliveryGroupChange>(),
+            new List<CartExtension.CartItemChange>(),
+            new List<CartExtension.CouponChange>());
+
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = new CartExtension.OptionalBuyerActionDetails();
+        optionalBuyerActionDetails.of(buyerActionDetails);
+
+        CartExtension.CartCalculateOrchestratorRequest request = new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails);
+
+        final CartCalculateExecutorForUnitTest executor = new CartCalculateExecutorForUnitTest();
+        CartCalculateSample cartCalculateSample = new CartCalculateSample(executor);
+
+        Test.startTest();
+
+        // Act
+        cartCalculateSample.calculate(request);
+        Test.stopTest();
+
+        // Assert
+        // Verify that no CVO was created
+        CartExtension.CartValidationOutputList cartValidationOutputs = cart.getCartValidationOutputs();
+        System.assertEquals(0, cartValidationOutputs.size());
+
+        // Verify that the promotions calculator made changes
+        System.assert(!cart.getName().contains('CartRepriced'));
+        System.assert(cart.getName().contains('PromotionsRecalculated'));
+        System.assert(!cart.getName().contains('InventoryChecked'));
+        System.assert(!cart.getName().contains('ShippingRecalculated'));
+        System.assert(!cart.getName().contains('TaxesRecalculated'));
+        System.assert(!cart.getName().contains('PostShippingCompleted'));
+    }
 }

--- a/commerce/domain/orchestrators/classes/CartCalculateSampleUnitTest.cls
+++ b/commerce/domain/orchestrators/classes/CartCalculateSampleUnitTest.cls
@@ -1,0 +1,190 @@
+/**
+ * A Sample unit test for <<CartCalculate>>.
+ */
+@IsTest
+public class CartCalculateSampleUnitTest {
+
+    @IsTest
+    public static void shouldRunPricingAndPromotionsWhenBuyerAddsToCart() {
+        // Arrange
+        // Create a cart
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        // Set up BuyerActions as if the Buyer has added an item to cart
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock();
+        buyerActions.setCartItemChanged(true);
+
+        // Set up BuyerActionDetails as if the Buyer has added an item to cart
+        final boolean isCheckoutStarted = false;
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails(
+            isCheckoutStarted,
+            new List<CartExtension.CartDeliveryGroupChange>(),
+            new List<CartExtension.CartItemChange>(),
+            new List<CartExtension.CouponChange>());
+
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = new CartExtension.OptionalBuyerActionDetails();
+        optionalBuyerActionDetails.of(buyerActionDetails);
+
+        CartExtension.CartCalculateOrchestratorRequest request = new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails);
+
+        final CartCalculateExecutorForUnitTest executor = new CartCalculateExecutorForUnitTest();
+        CartCalculateSample cartCalculateSample = new CartCalculateSample(executor);
+
+        Test.startTest();
+
+        // Act
+        cartCalculateSample.calculate(request);
+        Test.stopTest();
+
+        // Assert
+        // Verify that no CVO was created
+        CartExtension.CartValidationOutputList cartValidationOutputs = cart.getCartValidationOutputs();
+        System.assertEquals(0, cartValidationOutputs.size());
+
+        // Verify that the pricing and promotions calculators made changes
+        System.assert(cart.getName().contains('CartRepriced'));
+        System.assert(cart.getName().contains('PromotionsRecalculated'));
+        System.assert(!cart.getName().contains('InventoryChecked'));
+        System.assert(!cart.getName().contains('ShippingRecalculated'));
+        System.assert(!cart.getName().contains('TaxesRecalculated'));
+        System.assert(!cart.getName().contains('PostShippingCompleted'));
+    }
+
+    @IsTest
+    public static void shouldRunPricingPromotionsAndInventoryWhenBuyerStartsCheckout() {
+        // Arrange
+        // Create a cart
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        // Set up BuyerActions as if the Buyer has started Checkout
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock();
+        buyerActions.setCheckoutStarted(true);
+
+        // Set up BuyerActionDetails as if the Buyer has started Checkout
+        final boolean isCheckoutStarted = true;
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails(
+            isCheckoutStarted,
+            new List<CartExtension.CartDeliveryGroupChange>(),
+            new List<CartExtension.CartItemChange>(),
+            new List<CartExtension.CouponChange>());
+
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = new CartExtension.OptionalBuyerActionDetails();
+        optionalBuyerActionDetails.of(buyerActionDetails);
+
+        CartExtension.CartCalculateOrchestratorRequest request = new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails);
+
+        final CartCalculateExecutorForUnitTest executor = new CartCalculateExecutorForUnitTest();
+        CartCalculateSample cartCalculateSample = new CartCalculateSample(executor);
+
+        Test.startTest();
+
+        // Act
+        cartCalculateSample.calculate(request);
+        Test.stopTest();
+
+        // Assert
+        // Verify that no CVO was created
+        CartExtension.CartValidationOutputList cartValidationOutputs = cart.getCartValidationOutputs();
+        System.assertEquals(0, cartValidationOutputs.size());
+
+        // Verify that the pricing, promotions, and inventory calculators made changes
+        System.assert(cart.getName().contains('CartRepriced'));
+        System.assert(cart.getName().contains('PromotionsRecalculated'));
+        System.assert(cart.getName().contains('InventoryChecked'));
+        System.assert(!cart.getName().contains('ShippingRecalculated'));
+        System.assert(!cart.getName().contains('TaxesRecalculated'));
+        System.assert(!cart.getName().contains('PostShippingCompleted'));
+    }
+
+    @IsTest
+    public static void shouldRunShippingTaxesAndPostShippingWhenBuyerUpdatesShippingAddress() {
+        // Arrange
+        // Create a cart
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        // Set up BuyerActions as if the Buyer has updated their shipping address
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock();
+        buyerActions.setDeliveryGroupChanged(true);
+
+        // Set up BuyerActionDetails as if the Buyer has updated their shipping address
+        final boolean isCheckoutStarted = false;
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails(
+            isCheckoutStarted,
+            new List<CartExtension.CartDeliveryGroupChange>(),
+            new List<CartExtension.CartItemChange>(),
+            new List<CartExtension.CouponChange>());
+
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = new CartExtension.OptionalBuyerActionDetails();
+        optionalBuyerActionDetails.of(buyerActionDetails);
+
+        CartExtension.CartCalculateOrchestratorRequest request = new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails);
+
+        final CartCalculateExecutorForUnitTest executor = new CartCalculateExecutorForUnitTest();
+        CartCalculateSample cartCalculateSample = new CartCalculateSample(executor);
+
+        Test.startTest();
+
+        // Act
+        cartCalculateSample.calculate(request);
+        Test.stopTest();
+
+        // Assert
+        // Verify that no CVO was created
+        CartExtension.CartValidationOutputList cartValidationOutputs = cart.getCartValidationOutputs();
+        System.assertEquals(0, cartValidationOutputs.size());
+
+        // Verify that the shipping, taxes, and post shipping calculators made changes
+        System.assert(!cart.getName().contains('CartRepriced'));
+        System.assert(!cart.getName().contains('PromotionsRecalculated'));
+        System.assert(!cart.getName().contains('InventoryChecked'));
+        System.assert(cart.getName().contains('ShippingRecalculated'));
+        System.assert(cart.getName().contains('TaxesRecalculated'));
+        System.assert(cart.getName().contains('PostShippingCompleted'));
+    }
+
+    @IsTest
+    public static void shouldRunPostShippingAndTaxesWhenBuyerSelectsDeliveryMethod() {
+        // Arrange
+        // Create a cart
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        // Set up BuyerActions as if the Buyer selected a Delivery Method
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock();
+        buyerActions.setDeliveryMethodSelected(true);
+
+        // Set up BuyerActionDetails as if the Buyer selected a Delivery Method
+        final boolean isCheckoutStarted = false;
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails(
+            isCheckoutStarted,
+            new List<CartExtension.CartDeliveryGroupChange>(),
+            new List<CartExtension.CartItemChange>(),
+            new List<CartExtension.CouponChange>());
+
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = new CartExtension.OptionalBuyerActionDetails();
+        optionalBuyerActionDetails.of(buyerActionDetails);
+
+        CartExtension.CartCalculateOrchestratorRequest request = new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails);
+
+        final CartCalculateExecutorForUnitTest executor = new CartCalculateExecutorForUnitTest();
+        CartCalculateSample cartCalculateSample = new CartCalculateSample(executor);
+
+        Test.startTest();
+
+        // Act
+        cartCalculateSample.calculate(request);
+        Test.stopTest();
+
+        // Assert
+        // Verify that no CVO was created
+        CartExtension.CartValidationOutputList cartValidationOutputs = cart.getCartValidationOutputs();
+        System.assertEquals(0, cartValidationOutputs.size());
+
+        // Verify that the taxes and post shipping calculators made changes
+        System.assert(!cart.getName().contains('CartRepriced'));
+        System.assert(!cart.getName().contains('PromotionsRecalculated'));
+        System.assert(!cart.getName().contains('InventoryChecked'));
+        System.assert(!cart.getName().contains('ShippingRecalculated'));
+        System.assert(cart.getName().contains('TaxesRecalculated'));
+        System.assert(cart.getName().contains('PostShippingCompleted'));
+    }
+}


### PR DESCRIPTION
**Overview**

Adding a sample orchestrator utest class and required dependencies to unit test a custom CCA orchestrator.

**Testing Details**

- Ran these test cases in an org in Steam and seeing `78%` code coverage for the sample orchestrator.

**Testing Screenshots**

![Screenshot 2023-08-01 at 12 40 18 PM](https://github.com/forcedotcom/commerce-extensibility/assets/100236257/10958b89-540c-4c15-ac85-ce3ea392ffd9)
