### PR TITLE
Added account address endpoint extension samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn.lock
 *.DS_Store
 **/.DS_Store
 .sfdx/
+.vim-force.com/

--- a/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
@@ -1,4 +1,6 @@
-// This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId} and Commerce_Endpoint_Account_Address
+/**
+  *This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId} and Commerce_Endpoint_Account_Address
+  */
 public with sharing class AddressExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
 
     public override ConnectApi.EndpointExtensionRequest beforePatch(ConnectApi.EndpointExtensionRequest request) {

--- a/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
@@ -1,12 +1,21 @@
 /**
-  *This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId} and Commerce_Endpoint_Account_Address
+  * This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId} and Commerce_Endpoint_Account_Address
   */
+
+/**
+* Sample extension provider for updating addresses
+* This corresponds to the endpoint /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses
+* and is identified by the EPN Commerce_Endpoint_Account_Addresses for registration/mapping
+*/
 public with sharing class AddressExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
 
     public override ConnectApi.EndpointExtensionRequest beforePatch(ConnectApi.EndpointExtensionRequest request) {
         System.debug('We are in the beforePatch entry method of of Commerce_Endpoint_Account_Address extension');
 
-        // Get the address for zip cleansing. This is a deep copy.
+        /*
+         * Get the address for zip cleansing. This is a deep copy. 
+         * The parameter name can be found in the documentation: https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/extensions.html
+        */ 
         ConnectApi.CommerceAddressInput address = (ConnectApi.CommerceAddressInput)request.getParam('addressInput');
 
         // Will update the address to a valid zip format or throw an error.

--- a/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
@@ -1,0 +1,19 @@
+// This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId} and Commerce_Endpoint_Account_Address
+public with sharing class AddressExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
+
+    public override ConnectApi.EndpointExtensionRequest beforePatch(ConnectApi.EndpointExtensionRequest request) {
+        System.debug('We are in the beforePatch entry method of of Commerce_Endpoint_Account_Address extension');
+
+        // Get the address for zip cleansing. This is a deep copy.
+        ConnectApi.CommerceAddressInput address = (ConnectApi.CommerceAddressInput)request.getParam('addressInput');
+
+        // Will update the address to a valid zip format or throw an error.
+        if (UsZipCleansingSample.cleanseUsZip(address)) {
+            // The request needs to be set on the "before" methods since what is returned is a deep copy.
+            request.setParam('addressInput', address);
+        }
+
+        return request;
+    }
+
+}

--- a/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls
@@ -1,14 +1,13 @@
 /**
-  * This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId} and Commerce_Endpoint_Account_Address
-  */
-
-/**
 * Sample extension provider for updating addresses
 * This corresponds to the endpoint /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses
 * and is identified by the EPN Commerce_Endpoint_Account_Addresses for registration/mapping
 */
 public with sharing class AddressExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
 
+    /*
+     * Cleanses the US zip on address update
+     */
     public override ConnectApi.EndpointExtensionRequest beforePatch(ConnectApi.EndpointExtensionRequest request) {
         System.debug('We are in the beforePatch entry method of of Commerce_Endpoint_Account_Address extension');
 

--- a/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls-meta.xml
+++ b/commerce/endpoint/account/address/classes/AddressExtensionProviderSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls
@@ -5,6 +5,9 @@
 */
 public with sharing class AddressesExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
 
+    /*
+     * Updates the address name values in the GET response if it doesn't exist.
+     */
     public override ConnectApi.EndpointExtensionResponse afterGet(ConnectApi.EndpointExtensionResponse response, ConnectApi.EndpointExtensionRequest request) {
 
         System.debug('We are in the afterGet entry method of Commerce_Endpoint_Account_Addresses extension');
@@ -12,8 +15,13 @@ public with sharing class AddressesExtensionProviderSample extends ConnectApi.Ba
         // Get the response object, the list of addresses. 
         ConnectApi.CommerceAddressCollection output = (ConnectApi.CommerceAddressCollection)response.getResponseObject();
 
-        // Iterate through the addresses, set the name name for each address to a concatenation of the first and last name, if it hasn't been populated. Note: The change to the name field is not persisted, this means if the name field was not set but a value is returned through an endpoint using this extension, a SOQL lookup will NOT return a value for the name field.
-        // The "after" methods have access to direct manipulation on the objects. 
+        /*
+         *
+         *  Iterate through the addresses, set the name name for each address to a concatenation of the first and last name, if it hasn't been populated. 
+         *     Note: The change to the name field is not persisted, this means if the name field was not set but a value is returned through an endpoint using this extension, 
+         *     a SOQL lookup will NOT return a value for the name field.
+         *  The "after" methods have access to direct manipulation on the objects. 
+         */
         List<ConnectApi.CommerceAddressOutput> addresses = output.getItems();
         for (ConnectApi.CommerceAddressOutput address : addresses) {
             if (String.isEmpty(address.getName())) {
@@ -24,6 +32,9 @@ public with sharing class AddressesExtensionProviderSample extends ConnectApi.Ba
         return response;
     }
 
+    /*
+     * Cleanses the US zip on address creation
+     */
      public override ConnectApi.EndpointExtensionRequest beforePost(ConnectApi.EndpointExtensionRequest request) {
         
         System.debug('We are in the beforePost entry method of of Commerce_Endpoint_Account_Addresses extension');

--- a/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls
@@ -1,8 +1,11 @@
-// This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses and Commerce_Endpoint_Account_Addresses
+/**
+* Sample extension provider for creating/retriving addresses, covering before and after entry methods
+* This corresponds to the endpoint /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses
+* and is identified by the EPN Commerce_Endpoint_Account_Addresses for registration/mapping
+*/
 public with sharing class AddressesExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
 
-    public override ConnectApi.EndpointExtensionResponse afterGet(ConnectApi.EndpointExtensionResponse response, 
-            ConnectApi.EndpointExtensionRequest request) {
+    public override ConnectApi.EndpointExtensionResponse afterGet(ConnectApi.EndpointExtensionResponse response, ConnectApi.EndpointExtensionRequest request) {
 
         System.debug('We are in the afterGet entry method of Commerce_Endpoint_Account_Addresses extension');
 
@@ -24,8 +27,11 @@ public with sharing class AddressesExtensionProviderSample extends ConnectApi.Ba
      public override ConnectApi.EndpointExtensionRequest beforePost(ConnectApi.EndpointExtensionRequest request) {
         
         System.debug('We are in the beforePost entry method of of Commerce_Endpoint_Account_Addresses extension');
-        
-        // Get the address for zip cleansing. This is a deep copy.
+
+        /*
+         * Get the address for zip cleansing. This is a deep copy. 
+         * The parameter name can be found in the documentation: https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/extensions.html
+        */ 
         ConnectApi.CommerceAddressInput address = (ConnectApi.CommerceAddressInput)request.getParam('addressInput');
 
         // Will update the address to a valid zip format or throw an error.        

--- a/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls
+++ b/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls
@@ -1,0 +1,39 @@
+// This corresponds to /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses and Commerce_Endpoint_Account_Addresses
+public with sharing class AddressesExtensionProviderSample extends ConnectApi.BaseEndpointExtension {
+
+    public override ConnectApi.EndpointExtensionResponse afterGet(ConnectApi.EndpointExtensionResponse response, 
+            ConnectApi.EndpointExtensionRequest request) {
+
+        System.debug('We are in the afterGet entry method of Commerce_Endpoint_Account_Addresses extension');
+
+        // Get the response object, the list of addresses. 
+        ConnectApi.CommerceAddressCollection output = (ConnectApi.CommerceAddressCollection)response.getResponseObject();
+
+        // Iterate on the addresses and set the name to the first name plus last name if it does not exist.
+        // The "after" methods have access to direct manipulation on the objects. 
+        List<ConnectApi.CommerceAddressOutput> items = output.getItems();
+        for (ConnectApi.CommerceAddressOutput address : items) {
+            if (String.isEmpty(address.getName())) {
+                address.setName(address.getFirstName() + ' ' + address.getLastName());
+            }
+        }
+
+        return response;
+    }
+
+     public override ConnectApi.EndpointExtensionRequest beforePost(ConnectApi.EndpointExtensionRequest request) {
+        
+        System.debug('We are in the beforePost entry method of of Commerce_Endpoint_Account_Addresses extension');
+        
+        // Get the address for zip cleansing. This is a deep copy.
+        ConnectApi.CommerceAddressInput address = (ConnectApi.CommerceAddressInput)request.getParam('addressInput');
+
+        // Will update the address to a valid zip format or throw an error.        
+        if (UsZipCleansingSample.cleanseUsZip(address)) {
+            // Since the address is a deep copy, the request needs to be updated.
+            request.setParam('addressInput', address);
+        }
+
+        return request;
+    }
+}

--- a/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls-meta.xml
+++ b/commerce/endpoint/account/address/classes/AddressesExtensionProviderSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/endpoint/account/address/classes/InvalidAddressSampleException.cls
+++ b/commerce/endpoint/account/address/classes/InvalidAddressSampleException.cls
@@ -1,0 +1,1 @@
+public with sharing class InvalidAddressSampleException extends Exception {}

--- a/commerce/endpoint/account/address/classes/InvalidAddressSampleException.cls-meta.xml
+++ b/commerce/endpoint/account/address/classes/InvalidAddressSampleException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
+++ b/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
@@ -21,7 +21,7 @@ public with sharing class UsZipCleansingSample {
         if (isValidZip(cleansedZip)) {
             return cleansedZip ;
         } else {
-            throw new CustomEndpointExtensionException(cleansedZip + ' is not a valid US postal code');
+            throw new InvalidAddressSampleException(cleansedZip + ' is not a valid US postal code');
         }
     }
 

--- a/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
+++ b/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
@@ -1,0 +1,32 @@
+public with sharing class UsZipCleansingSample {
+
+    private static Pattern validZipPattern = Pattern.compile('(^\\d{5}$)|(^\\d{9}$)|(^\\d{5}-\\d{4}$)');
+
+    // Returns whether it needed to be cleansed or not
+    public static boolean cleanseUsZip(ConnectApi.CommerceAddressInput address) {
+
+        if (address.getCountry().equals('US')) {
+            String zipIn = address.getPostalCode() ;
+            if (! isValidZip(zipIn)) {
+                // Try to cleanse if it is not valid
+                address.setPostalCode(cleanseZip(zipIn));
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String cleanseZip(String zipIn) {
+        String cleansedZip = zipIn.replaceAll('\\D','');
+        if (isValidZip(cleansedZip)) {
+            return cleansedZip ;
+        } else {
+            throw new CustomEndpointExtensionException(cleansedZip + ' is not a valid US postal code');
+        }
+    }
+
+    private static Boolean isValidZip(String zip) {
+        return validZipPattern.matcher(zip).matches();
+    }    
+
+}

--- a/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
+++ b/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
@@ -1,10 +1,13 @@
+/*
+ * Class that strips out all of the non-digit characters and throws an exception if the
+ * resulting value is not a 5 or 9 digit zip.
+ */
 public with sharing class UsZipCleansingSample {
 
     private static Pattern validZipPattern = Pattern.compile('(^\\d{5}$)|(^\\d{9}$)|(^\\d{5}-\\d{4}$)');
 
     // Returns whether it needed to be cleansed or not
     public static boolean cleanseUsZip(ConnectApi.CommerceAddressInput address) {
-
         if (address.getCountry().equals('US')) {
             String zipIn = address.getPostalCode() ;
             if (! isValidZip(zipIn)) {
@@ -16,6 +19,7 @@ public with sharing class UsZipCleansingSample {
         return false;
     }
 
+    // Strips non-digit values and throws exception if not a valid zip.
     private static String cleanseZip(String zipIn) {
         String cleansedZip = zipIn.replaceAll('\\D','');
         if (isValidZip(cleansedZip)) {

--- a/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
+++ b/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls
@@ -2,7 +2,7 @@
  * Class that strips out all of the non-digit characters and throws an exception if the
  * resulting value is not a 5 or 9 digit zip.
  */
-public with sharing class UsZipCleansingSample {
+public class UsZipCleansingSample {
 
     private static Pattern validZipPattern = Pattern.compile('(^\\d{5}$)|(^\\d{9}$)|(^\\d{5}-\\d{4}$)');
 

--- a/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls-meta.xml
+++ b/commerce/endpoint/account/address/classes/UsZipCleansingSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Zip cleansing (before PUT/before POST) and name updating (after GET) examples for:

Commerce_Endpoint_Account_Address: /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses/${addressId}

Commerce_Endpoint_Account_Addresses: /commerce/webstores/${webstoreId}/accounts/${accountId}/addresses
