### PR TITLE
@W-14508101 | Split Shipment Sample Apex

### DIFF
--- a/commerce/domain/shipping/splitshipment/SplitShipmentCallsSuper.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentCallsSuper.cls
@@ -4,11 +4,6 @@
 global class SplitShipmentCallsSuper extends CartExtension.SplitShipmentService {
 
     /**
-     * @description All classes extending CartExtension.SplitShipmentService must have a default constructor defined.
-     */
-    global SplitShipmentCallsSuper() {}
-
-    /**
      * @description Constructor used by unit tests only. See <<SplitShipmentUnitTest>>.
      * @param mockService Mocked service which can be used to stub the default Split Shipment logic.
      */

--- a/commerce/domain/shipping/splitshipment/SplitShipmentCallsSuper.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentCallsSuper.cls
@@ -1,0 +1,22 @@
+/**
+ * @description Sample Split Shipment Service Apex that calls the default implementation.
+ */
+global class SplitShipmentCallsSuper extends CartExtension.SplitShipmentService {
+
+    /**
+     * @description All classes extending CartExtension.SplitShipmentService must have a default constructor defined.
+     */
+    global SplitShipmentCallsSuper() {}
+
+    /**
+     * @description Constructor used by unit tests only. See <<SplitShipmentUnitTest>>.
+     * @param mockService Mocked service which can be used to stub the default Split Shipment logic.
+     */
+    global SplitShipmentCallsSuper(final CartExtension.SplitShipmentServiceMock mockService) {
+        super(mockService);
+    }
+
+    public override void arrangeItems(CartExtension.ItemArrangementRequest request) {
+        super.arrangeItems(request);
+    }
+}

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -94,7 +94,14 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
         cartDeliveryGroup.setName('Non-Conveyable Cart Delivery Group');
         cartDeliveryGroup.setCustomField('IsConveyable__c', false);
 
-        Address deliveryAddress = itemArrange.getDeliveryAddress();
+        Address deliveryAddress;
+
+        if (itemArrange.getDeliveryGroupId() != null) {
+            CartDeliveryGroup cdg = [SELECT DeliverToAddress from CartDeliveryGroup where Id =: itemArrange.getDeliveryGroupId()];
+            deliveryAddress = cdg.DeliverToAddress;
+        } else {
+            deliveryAddress = itemArrange.getDeliveryAddress();
+        }
 
         if (deliveryAddress != null) {
             if (deliveryAddress.getStreet() != null) {

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -3,93 +3,76 @@
  */
 global class SplitShipmentSample extends CartExtension.SplitShipmentService {
 
-    /**
-     * @description All classes extending CartExtension.SplitShipmentService must have a default constructor defined.
-     */
-    global SplitShipmentSample() {}
-
     public virtual override void arrangeItems(CartExtension.ItemArrangementRequest request) {
         CartExtension.Cart cart = request.getCart();
 
-        Iterator<CartExtension.ItemArrange> itemArrangeIterator = request.getItemArrangeList().iterator();
-        while (itemArrangeIterator.hasNext()) {
-            arrangeItemsByCartItemQuantity(cart, itemArrangeIterator.next());
+        Iterator<CartExtension.ItemArrange> iterator = request.getItemArrangeList().iterator();
+        while (iterator.hasNext()) {
+            CartExtension.ItemArrange itemArrange = iterator.next();
+            arrangeItemsByProductConveyability(cart, itemArrange);
         }
     }
 
     /**
-     * @description Item arrangement algorithm based on a maximum CartItem quantity per CartDeliveryGroup.
+     * @description Split up the shipment by conveyable and non-conveyable products. Products that are non-conveyable
+     * cannot go on the conveyor belt at the warehouse because they are too big, bulky, and/or heavy. This means that
+     * these non-conveyable items may require additional packaging and will take longer to get onto a delivery truck.
      * @param cart Holds details about a Cart
-     * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
+     * @param itemArrange Holds information on how the item should be arranged
      */
-    private void arrangeItemsByCartItemQuantity(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
-        // Find the CartItem using the cartItemId provided by the ItemArrange object
-        Iterator<CartExtension.CartItem> cartItemsIterator = cart.getCartItems().iterator();
-        while (cartItemsIterator.hasNext()) {
-            CartExtension.CartItem cartItem = cartItemsIterator.next();
-            if (cartItem.getId() == itemArrange.getCartItemId()) {
-                // Check to see if we need to create more CartDeliveryGroups based on quantity
-                if (shouldSplitShipmentByQuantity(cartItem.getQuantity(), itemArrange.getQuantity())) {
-                    splitShipmentByQuantity(cart, cartItem, itemArrange);
-                }
+    private void arrangeItemsByProductConveyability(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
+        // Get conveyable info for the product
+        List<Product2> products = [SELECT IsConveyable__c FROM Product2 WHERE Id =: itemArrange.getProductId() LIMIT 1];
+        Boolean isConveyable = Boolean.valueOf(products[0].IsConveyable__c);
+
+        // If the product is non-conveyable, then we need to move the item to a non-conveyable CartDeliveryGroup
+        if (!isConveyable) {
+            // Check to see if we already have a CartDeliveryGroup for non-conveyable items
+            CartExtension.CartDeliveryGroup nonConveyableCartDeliveryGroup = findNonConveyableCartDeliveryGroup(cart);
+
+            if (nonConveyableCartDeliveryGroup == null) {
+                // Create a CartDeliveryGroup for items that are non-conveyable
+                nonConveyableCartDeliveryGroup = createNonConveyableCartDeliveryGroup(cart, itemArrange);
+            }
+
+            // Move the non-conveyable CartItem to the non-conveyable CartDeliveryGroup
+            moveCartItemToTargetCartDeliveryGroup(cart, itemArrange, nonConveyableCartDeliveryGroup);
+        }
+    }
+
+    /**
+     * @description Check to see if we already have a non-conveyable CartDeliveryGroup in the Cart and if so, return it.
+     * @param cart Holds details about a Cart
+     *
+     * @return CartExtension.CartDeliveryGroup
+     */
+    private CartExtension.CartDeliveryGroup findNonConveyableCartDeliveryGroup(CartExtension.Cart cart) {
+        Iterator<CartExtension.CartDeliveryGroup> iterator = cart.getCartDeliveryGroups().iterator();
+        while (iterator.hasNext()) {
+            CartExtension.CartDeliveryGroup cartDeliveryGroup = iterator.next();
+
+            // Check to see if we already have a CartDeliveryGroup for non-conveyable items
+            if (!(Boolean)cartDeliveryGroup.getCustomField('IsConveyable__c')) {
+                return cartDeliveryGroup;
             }
         }
+
+        // We don't have a CartDeliveryGroup
+        return null;
     }
 
     /**
-     * @description Determines whether or not the shipment should be split into multiple shipments, based on quantity.
-     * @param cartItemQuantity Quantity associated to a CartItem
-     * @param maxCartItemQuantityPerDeliveryGroup Maximum CartItem quantity per CartDeliveryGroup (provided by ItemArrange)
-     *
-     * @return Boolean True if the quantity associated to the CartItem exceeds the quantity associated to ItemArrange
-     */
-    private Boolean shouldSplitShipmentByQuantity(Decimal cartItemQuantity, Decimal maxCartItemQuantityPerDeliveryGroup) {
-        return cartItemQuantity > maxCartItemQuantityPerDeliveryGroup;
-    }
-
-    /**
-     * @description Splits the shipment into N CartItems and N CartDeliveryGroups, based on quantity.
+     * @description Creates a Cart Delivery Group for items that cannot go on the conveyor belt in the warehouse.
      * @param cart Holds details about a Cart
-     * @param cartItem Holds details about a CartItem
      * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
      */
-    private void splitShipmentByQuantity(CartExtension.Cart cart, CartExtension.CartItem cartItem, CartExtension.ItemArrange itemArrange) {
-        // Adjust the original CartItem's quantity to maxCartItemQuantityPerDeliveryGroup and create N number of
-        // CartItems and CartDeliveryGroups until we've accounted for the entire quantity
-        Decimal maxCartItemQuantityPerDeliveryGroup = itemArrange.getQuantity();
-        Decimal remainingQuantity = cartItem.getQuantity() - maxCartItemQuantityPerDeliveryGroup;
-        cartItem.setQuantity(maxCartItemQuantityPerDeliveryGroup);
+    private CartExtension.CartDeliveryGroup createNonConveyableCartDeliveryGroup(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
+        // Set up the non-conveyable CartDeliveryGroup
+        CartExtension.CartDeliveryGroup cartDeliveryGroup = new CartExtension.CartDeliveryGroup();
+        cartDeliveryGroup.setName('Non-Conveyable Cart Delivery Group');
+        cartDeliveryGroup.setCustomField('IsConveyable__c', false);
 
         Address deliveryAddress = itemArrange.getDeliveryAddress();
-        Integer numCartItems = cart.getCartItems().size();
-        Integer cartItemNumber = numCartItems + 1;
-        while (remainingQuantity > 0) {
-            // Create a new CartDeliveryGroup
-            CartExtension.CartDeliveryGroup cartDeliveryGroup = createCartDeliveryGroup(cart, itemArrange, deliveryAddress);
-
-            // Create a new CartItem and associate it to the newly created CartDeliveryGroup
-            CartExtension.CartItem newCartItem = new CartExtension.CartItem(CartExtension.SalesItemTypeEnum.PRODUCT, cartDeliveryGroup, 'My Cart Item ' + cartItemNumber++);
-            newCartItem.setProduct2Id(itemArrange.getProductId());
-            // Update the new CartItem quantity to whichever is smaller, either the remainingQuantity or
-            // maxCartItemQuantityPerDeliveryGroup, so that we don't include more quantity of the CartItem than required
-            newCartItem.setQuantity(Math.min(remainingQuantity, maxCartItemQuantityPerDeliveryGroup));
-
-            // Associate the new CartItem to the Cart
-            cart.getCartItems().add(newCartItem);
-
-            // Adjust the remaining quantity that still needs to be accounted
-            remainingQuantity -= maxCartItemQuantityPerDeliveryGroup;
-        }
-    }
-
-    /**
-     * @description Creates a Cart Delivery Group.
-     * @param cart Holds details about a Cart
-     * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
-     * @param deliveryAddress Address information for where the item is being delivered
-     */
-    private CartExtension.CartDeliveryGroup createCartDeliveryGroup(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange, Address deliveryAddress) {
-        CartExtension.CartDeliveryGroup cartDeliveryGroup = new CartExtension.CartDeliveryGroup();
 
         if (deliveryAddress != null) {
             if (deliveryAddress.getStreet() != null) {
@@ -124,5 +107,23 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
 
         cart.getCartDeliveryGroups().add(cartDeliveryGroup);
         return cartDeliveryGroup;
+    }
+
+    /**
+     * @description Move the CartItem to the provided CartDeliveryGroup.
+     * @param cart Representation of a WebCart
+     * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
+     * @param targetCartDeliveryGroup The CartDeliveryGroup to which the provided CartItem should be moved
+     */
+    private void moveCartItemToTargetCartDeliveryGroup(CartExtension.Cart cart,
+            CartExtension.ItemArrange itemArrange,
+            CartExtension.CartDeliveryGroup targetCartDeliveryGroup) {
+        Iterator<CartExtension.CartItem> iterator = cart.getCartItems().iterator();
+        while (iterator.hasNext()) {
+            CartExtension.CartItem cartItem = iterator.next();
+            if (cartItem.getId() == itemArrange.getCartItemId()) {
+                cartItem.setCartDeliveryGroup(targetCartDeliveryGroup);
+            }
+        }
     }
 }

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -1,0 +1,198 @@
+/**
+ * @description Custom Split Shipment Service sample.
+ */
+global class SplitShipmentSample extends CartExtension.SplitShipmentService {
+
+    /**
+     * @description All classes extending CartExtension.SplitShipmentService must have a default constructor defined.
+     */
+    global SplitShipmentSample() {}
+
+    /**
+     * @description Constructor used by unit tests only. See <<SplitShipmentUnitTest>>.
+     * @param mockService Mocked service which can be used to stub the default Split Shipment logic.
+     */
+    global SplitShipmentSample(final CartExtension.SplitShipmentServiceMock mockService) {
+        super(mockService);
+    }
+
+    public virtual override void arrangeItems(CartExtension.ItemArrangementRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        List<CartExtension.ItemArrange> itemArrangeList = request.getItemArrangeList();
+
+        for (CartExtension.ItemArrange itemArrange : itemArrangeList) {
+            CartExtension.CartDeliveryGroup cartDeliveryGroup = findOrCreateDeliveryGroup(cart, itemArrange);
+            updateOrCreateCartItemToCartDeliveryGroup(cart, cartDeliveryGroup, itemArrange);
+        }
+    }
+
+    /**
+     * @description Either finds a Cart Delivery Group based on the given inputs or creates a new one.
+     * @param cart Representation of a `WebCart` record
+     * @param itemArrange Holds details of how to arrange an item between delivery groups
+     */
+    private CartExtension.CartDeliveryGroup findOrCreateDeliveryGroup(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
+        Address deliveryAddress = itemArrange.getDeliveryAddress();
+
+        if (itemArrange.getDeliveryGroupId() != null) {
+            Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
+            while (cdgIterator.hasNext()) {
+                CartExtension.CartDeliveryGroup cartDeliveryGroup = cdgIterator.next();
+                if (cartDeliveryGroup.getId() == itemArrange.getDeliveryGroupId()) {
+                    return cartDeliveryGroup;
+                }
+            }
+        } else if ((itemArrange.getDeliveryAddress() != null || itemArrange.getDeliveryAddressId() != null) && itemArrange.getDeliveryGroupName() != null) {
+            Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
+
+            if (itemArrange.getDeliveryAddress() != null) {
+                deliveryAddress = itemArrange.getDeliveryAddress();
+            } else {
+                ID accountId = cart.getAccountId();
+                ID addressId = itemArrange.getDeliveryAddressId();
+                ContactPointAddress contactPointAddress = [SELECT Address FROM ContactPointAddress WHERE (ParentId = :accountId AND Id = :addressId) LIMIT 1];
+                deliveryAddress = contactPointAddress.Address;
+            }
+            while (cdgIterator.hasNext()) {
+                CartExtension.CartDeliveryGroup cartDeliveryGroup = cdgIterator.next();
+                if (areAddressesEqual(deliveryAddress, cartDeliveryGroup.getDeliverToAddress()) && itemArrange.getDeliveryGroupName().equals(cartDeliveryGroup.getName())) {
+                    return cartDeliveryGroup;
+                }
+            }
+        }
+        return createCartDeliveryGroup(cart, itemArrange, deliveryAddress);
+    }
+
+    /**
+     * @description Creates a Cart Delivery Group.
+     * @param cart Representation of a `WebCart` record
+     * @param itemArrange Holds details of how to arrange an item between delivery groups
+     * @param deliveryAddress Address information for where the item is being delivered
+     */
+    private CartExtension.CartDeliveryGroup createCartDeliveryGroup(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange, Address deliveryAddress) {
+        CartExtension.CartDeliveryGroup cartDeliveryGroup = new CartExtension.CartDeliveryGroup();
+
+        if (itemArrange.getDeliveryGroupName() != null) {
+            cartDeliveryGroup.setName(itemArrange.getDeliveryGroupName());
+        }
+
+        if (deliveryAddress != null) {
+            if (deliveryAddress.getStreet() != null) {
+                cartDeliveryGroup.setDeliverToStreet(deliveryAddress.getStreet());
+            }
+            if (deliveryAddress.getCity() != null) {
+                cartDeliveryGroup.setDeliverToCity(deliveryAddress.getCity());
+            }
+            if (deliveryAddress.getState() != null) {
+                cartDeliveryGroup.setDeliverToState(deliveryAddress.getState());
+            }
+            if (deliveryAddress.getPostalCode() != null) {
+                cartDeliveryGroup.setDeliverToPostalCode(deliveryAddress.getPostalCode());
+            }
+            if (deliveryAddress.getCountry() != null) {
+                cartDeliveryGroup.setDeliverToCountry(deliveryAddress.getCountry());
+            }
+            if (deliveryAddress.getStateCode() != null) {
+                cartDeliveryGroup.setDeliverToStateCode(deliveryAddress.getStateCode());
+            }
+            if (deliveryAddress.getCountryCode() != null) {
+                cartDeliveryGroup.setDeliverToCountryCode(deliveryAddress.getCountryCode());
+            }
+            if (deliveryAddress.getLatitude() != null) {
+                cartDeliveryGroup.setDeliverToLatitude(deliveryAddress.getLatitude());
+            }
+            if (deliveryAddress.getLongitude() != null) {
+                cartDeliveryGroup.setDeliverToLongitude(deliveryAddress.getLongitude());
+            }
+            if (deliveryAddress.getGeocodeAccuracy() != null) {
+                cartDeliveryGroup.setDeliverToGeocodeAccuracy(deliveryAddress.getGeocodeAccuracy());
+            }
+        }
+
+        if (itemArrange.getDeliverToName() != null) {
+            cartDeliveryGroup.setDeliverToName(itemArrange.getDeliverToName());
+        }
+        if (itemArrange.getDeliverToFirstName() != null) {
+            cartDeliveryGroup.setDeliverToFirstName(itemArrange.getDeliverToFirstName());
+        }
+        if (itemArrange.getDeliverToLastName() != null) {
+            cartDeliveryGroup.setDeliverToLastName(itemArrange.getDeliverToLastName());
+        }
+        if (itemArrange.getDeliverToCompanyName() != null) {
+            cartDeliveryGroup.setCompanyName(itemArrange.getDeliverToCompanyName());
+        }
+
+        cart.getCartDeliveryGroups().add(cartDeliveryGroup);
+        return cartDeliveryGroup;
+    }
+
+    /**
+     * @description Sets the quantity and associates the target Cart Delivery Group for a Cart Item, if it is provided. 
+     * If a Cart Item is not provided, then a new one is created with the provided quantity and Cart Delivery Group.
+     * 
+     * @param cart Representation of a `WebCart` record
+     * @param targetCartDeliveryGroup The Cart Delivery Group to associate with the Cart Item
+     * @param itemArrange Holds details of how to arrange an item between delivery groups
+     */
+    private void updateOrCreateCartItemToCartDeliveryGroup(CartExtension.Cart cart, CartExtension.CartDeliveryGroup targetCartDeliveryGroup, CartExtension.ItemArrange itemArrange) {
+        if (itemArrange.getCartItemId() == null) {
+            CartExtension.CartItem cartItem = new CartExtension.CartItem(CartExtension.SalesItemTypeEnum.PRODUCT, targetCartDeliveryGroup, 'My Cart Item');
+            cartItem.setProduct2Id(itemArrange.getProductId());
+            cartItem.setQuantity(itemArrange.getQuantity());
+            cart.getCartItems().add(cartItem);
+        } else {
+            Iterator<CartExtension.CartItem> cartItemsIterator = cart.getCartItems().iterator();
+            while (cartItemsIterator.hasNext()) {
+                CartExtension.CartItem cartItem = cartItemsIterator.next();
+                if (cartItem.getId() == itemArrange.getCartItemId()) {
+                    if (itemArrange.getQuantity() == 0.0) {
+                        cart.getCartItems().remove(cartItem);
+                    } else {
+                        cartItem.setQuantity(itemArrange.getQuantity());
+                        cartItem.setCartDeliveryGroup(targetCartDeliveryGroup);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @description Checks whether two addresses are equal.
+     * @param address1 Address 1
+     * @param address2 Address 2
+     */
+    private Boolean areAddressesEqual(Address address1, Address address2) {
+        if (address1 == null && address2 == null) {
+            return true;
+        }
+        if (address1 == null || address2 == null) {
+            return false;
+        }
+        if (address1.getCity() != address2.getCity()) {
+            return false;
+        }
+        if (address1.getCountry() != address2.getCountry()) {
+            return false;
+        }
+        if (address1.getCountryCode() != address2.getCountryCode()) {
+            return false;
+        }
+        if (address1.getGeocodeAccuracy() != address2.getGeocodeAccuracy()) {
+            return false;
+        }
+        if (address1.getPostalCode() != address2.getPostalCode()) {
+            return false;
+        }
+        if (address1.getState() != address2.getState()) {
+            return false;
+        }
+        if (address1.getStateCode() != address2.getStateCode()) {
+            return false;
+        }
+        if (address1.getStreet() != address2.getStreet()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -35,6 +35,7 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
         Address deliveryAddress = itemArrange.getDeliveryAddress();
 
         if (itemArrange.getDeliveryGroupId() != null) {
+            // 1. Use the DeliveryGroupId it to get the CartDeliveryGroup
             Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
             while (cdgIterator.hasNext()) {
                 CartExtension.CartDeliveryGroup cartDeliveryGroup = cdgIterator.next();
@@ -42,9 +43,11 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
                     return cartDeliveryGroup;
                 }
             }
-        } else if ((itemArrange.getDeliveryAddress() != null || itemArrange.getDeliveryAddressId() != null) && itemArrange.getDeliveryGroupName() != null) {
-            Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
+        } else if ((itemArrange.getDeliveryAddress() != null || itemArrange.getDeliveryAddressId() != null) 
+                    && itemArrange.getDeliveryGroupName() != null) {
+            // 2. Use the combination of DeliveryAddress + DeliveryGroupName to find the CartDeliveryGroup
 
+            // First, get the DeliveryAddress
             if (itemArrange.getDeliveryAddress() != null) {
                 deliveryAddress = itemArrange.getDeliveryAddress();
             } else {
@@ -53,6 +56,9 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
                 ContactPointAddress contactPointAddress = [SELECT Address FROM ContactPointAddress WHERE (ParentId = :accountId AND Id = :addressId) LIMIT 1];
                 deliveryAddress = contactPointAddress.Address;
             }
+
+            // Now, use the DeliveryAddress to get the CartDeliveryGroup
+            Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
             while (cdgIterator.hasNext()) {
                 CartExtension.CartDeliveryGroup cartDeliveryGroup = cdgIterator.next();
                 if (areAddressesEqual(deliveryAddress, cartDeliveryGroup.getDeliverToAddress()) && itemArrange.getDeliveryGroupName().equals(cartDeliveryGroup.getName())) {
@@ -60,6 +66,8 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
                 }
             }
         }
+
+        // 3. Otherwise, create a new CartDeliveryGroup
         return createCartDeliveryGroup(cart, itemArrange, deliveryAddress);
     }
 

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -8,81 +8,88 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
      */
     global SplitShipmentSample() {}
 
-    /**
-     * @description Constructor used by unit tests only. See <<SplitShipmentUnitTest>>.
-     * @param mockService Mocked service which can be used to stub the default Split Shipment logic.
-     */
-    global SplitShipmentSample(final CartExtension.SplitShipmentServiceMock mockService) {
-        super(mockService);
-    }
-
     public virtual override void arrangeItems(CartExtension.ItemArrangementRequest request) {
         CartExtension.Cart cart = request.getCart();
-        List<CartExtension.ItemArrange> itemArrangeList = request.getItemArrangeList();
 
-        for (CartExtension.ItemArrange itemArrange : itemArrangeList) {
-            CartExtension.CartDeliveryGroup cartDeliveryGroup = findOrCreateDeliveryGroup(cart, itemArrange);
-            updateOrCreateCartItemToCartDeliveryGroup(cart, cartDeliveryGroup, itemArrange);
+        Iterator<CartExtension.ItemArrange> itemArrangeIterator = request.getItemArrangeList().iterator();
+        while (itemArrangeIterator.hasNext()) {
+            arrangeItemsByCartItemQuantity(cart, itemArrangeIterator.next());
         }
     }
 
     /**
-     * @description Either finds a Cart Delivery Group based on the given inputs or creates a new one.
-     * @param cart Representation of a `WebCart` record
-     * @param itemArrange Holds details of how to arrange an item between delivery groups
+     * @description Item arrangement algorithm based on a maximum CartItem quantity per CartDeliveryGroup.
+     * @param cart Holds details about a Cart
+     * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
      */
-    private CartExtension.CartDeliveryGroup findOrCreateDeliveryGroup(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
-        Address deliveryAddress = itemArrange.getDeliveryAddress();
-
-        if (itemArrange.getDeliveryGroupId() != null) {
-            // 1. Use the DeliveryGroupId it to get the CartDeliveryGroup
-            Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
-            while (cdgIterator.hasNext()) {
-                CartExtension.CartDeliveryGroup cartDeliveryGroup = cdgIterator.next();
-                if (cartDeliveryGroup.getId() == itemArrange.getDeliveryGroupId()) {
-                    return cartDeliveryGroup;
-                }
-            }
-        } else if ((itemArrange.getDeliveryAddress() != null || itemArrange.getDeliveryAddressId() != null) 
-                    && itemArrange.getDeliveryGroupName() != null) {
-            // 2. Use the combination of DeliveryAddress + DeliveryGroupName to find the CartDeliveryGroup
-
-            // First, get the DeliveryAddress
-            if (itemArrange.getDeliveryAddress() != null) {
-                deliveryAddress = itemArrange.getDeliveryAddress();
-            } else {
-                ID accountId = cart.getAccountId();
-                ID addressId = itemArrange.getDeliveryAddressId();
-                ContactPointAddress contactPointAddress = [SELECT Address FROM ContactPointAddress WHERE (ParentId = :accountId AND Id = :addressId) LIMIT 1];
-                deliveryAddress = contactPointAddress.Address;
-            }
-
-            // Now, use the DeliveryAddress to get the CartDeliveryGroup
-            Iterator<CartExtension.CartDeliveryGroup> cdgIterator = cart.getCartDeliveryGroups().iterator();
-            while (cdgIterator.hasNext()) {
-                CartExtension.CartDeliveryGroup cartDeliveryGroup = cdgIterator.next();
-                if (areAddressesEqual(deliveryAddress, cartDeliveryGroup.getDeliverToAddress()) && itemArrange.getDeliveryGroupName().equals(cartDeliveryGroup.getName())) {
-                    return cartDeliveryGroup;
+    private void arrangeItemsByCartItemQuantity(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
+        // Find the CartItem using the cartItemId provided by the ItemArrange object
+        Iterator<CartExtension.CartItem> cartItemsIterator = cart.getCartItems().iterator();
+        while (cartItemsIterator.hasNext()) {
+            CartExtension.CartItem cartItem = cartItemsIterator.next();
+            if (cartItem.getId() == itemArrange.getCartItemId()) {
+                // Check to see if we need to create more CartDeliveryGroups based on quantity
+                if (shouldSplitShipmentByQuantity(cartItem.getQuantity(), itemArrange.getQuantity())) {
+                    splitShipmentByQuantity(cart, cartItem, itemArrange);
                 }
             }
         }
+    }
 
-        // 3. Otherwise, create a new CartDeliveryGroup
-        return createCartDeliveryGroup(cart, itemArrange, deliveryAddress);
+    /**
+     * @description Determines whether or not the shipment should be split into multiple shipments, based on quantity.
+     * @param cartItemQuantity Quantity associated to a CartItem
+     * @param maxCartItemQuantityPerDeliveryGroup Maximum CartItem quantity per CartDeliveryGroup (provided by ItemArrange)
+     *
+     * @return Boolean True if the quantity associated to the CartItem exceeds the quantity associated to ItemArrange
+     */
+    private Boolean shouldSplitShipmentByQuantity(Decimal cartItemQuantity, Decimal maxCartItemQuantityPerDeliveryGroup) {
+        return cartItemQuantity > maxCartItemQuantityPerDeliveryGroup;
+    }
+
+    /**
+     * @description Splits the shipment into N CartItems and N CartDeliveryGroups, based on quantity.
+     * @param cart Holds details about a Cart
+     * @param cartItem Holds details about a CartItem
+     * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
+     */
+    private void splitShipmentByQuantity(CartExtension.Cart cart, CartExtension.CartItem cartItem, CartExtension.ItemArrange itemArrange) {
+        // Adjust the original CartItem's quantity to maxCartItemQuantityPerDeliveryGroup and create N number of
+        // CartItems and CartDeliveryGroups until we've accounted for the entire quantity
+        Decimal maxCartItemQuantityPerDeliveryGroup = itemArrange.getQuantity();
+        Decimal remainingQuantity = cartItem.getQuantity() - maxCartItemQuantityPerDeliveryGroup;
+        cartItem.setQuantity(maxCartItemQuantityPerDeliveryGroup);
+
+        Address deliveryAddress = itemArrange.getDeliveryAddress();
+        Integer numCartItems = cart.getCartItems().size();
+        Integer cartItemNumber = numCartItems + 1;
+        while (remainingQuantity > 0) {
+            // Create a new CartDeliveryGroup
+            CartExtension.CartDeliveryGroup cartDeliveryGroup = createCartDeliveryGroup(cart, itemArrange, deliveryAddress);
+
+            // Create a new CartItem and associate it to the newly created CartDeliveryGroup
+            CartExtension.CartItem newCartItem = new CartExtension.CartItem(CartExtension.SalesItemTypeEnum.PRODUCT, cartDeliveryGroup, 'My Cart Item ' + cartItemNumber++);
+            newCartItem.setProduct2Id(itemArrange.getProductId());
+            // Update the new CartItem quantity to whichever is smaller, either the remainingQuantity or
+            // maxCartItemQuantityPerDeliveryGroup, so that we don't include more quantity of the CartItem than required
+            newCartItem.setQuantity(Math.min(remainingQuantity, maxCartItemQuantityPerDeliveryGroup));
+
+            // Associate the new CartItem to the Cart
+            cart.getCartItems().add(newCartItem);
+
+            // Adjust the remaining quantity that still needs to be accounted
+            remainingQuantity -= maxCartItemQuantityPerDeliveryGroup;
+        }
     }
 
     /**
      * @description Creates a Cart Delivery Group.
-     * @param cart Representation of a `WebCart` record
-     * @param itemArrange Holds details of how to arrange an item between delivery groups
+     * @param cart Holds details about a Cart
+     * @param itemArrange Holds details of how to arrange an item between CartDeliveryGroups
      * @param deliveryAddress Address information for where the item is being delivered
      */
     private CartExtension.CartDeliveryGroup createCartDeliveryGroup(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange, Address deliveryAddress) {
         CartExtension.CartDeliveryGroup cartDeliveryGroup = new CartExtension.CartDeliveryGroup();
-
-        if (itemArrange.getDeliveryGroupName() != null) {
-            cartDeliveryGroup.setName(itemArrange.getDeliveryGroupName());
-        }
 
         if (deliveryAddress != null) {
             if (deliveryAddress.getStreet() != null) {
@@ -99,21 +106,6 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
             }
             if (deliveryAddress.getCountry() != null) {
                 cartDeliveryGroup.setDeliverToCountry(deliveryAddress.getCountry());
-            }
-            if (deliveryAddress.getStateCode() != null) {
-                cartDeliveryGroup.setDeliverToStateCode(deliveryAddress.getStateCode());
-            }
-            if (deliveryAddress.getCountryCode() != null) {
-                cartDeliveryGroup.setDeliverToCountryCode(deliveryAddress.getCountryCode());
-            }
-            if (deliveryAddress.getLatitude() != null) {
-                cartDeliveryGroup.setDeliverToLatitude(deliveryAddress.getLatitude());
-            }
-            if (deliveryAddress.getLongitude() != null) {
-                cartDeliveryGroup.setDeliverToLongitude(deliveryAddress.getLongitude());
-            }
-            if (deliveryAddress.getGeocodeAccuracy() != null) {
-                cartDeliveryGroup.setDeliverToGeocodeAccuracy(deliveryAddress.getGeocodeAccuracy());
             }
         }
 
@@ -132,75 +124,5 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
 
         cart.getCartDeliveryGroups().add(cartDeliveryGroup);
         return cartDeliveryGroup;
-    }
-
-    /**
-     * @description Sets the quantity and associates the target Cart Delivery Group for a Cart Item, if it is provided. 
-     * If a Cart Item is not provided, then a new one is created with the provided quantity and Cart Delivery Group.
-     * 
-     * @param cart Representation of a `WebCart` record
-     * @param targetCartDeliveryGroup The Cart Delivery Group to associate with the Cart Item
-     * @param itemArrange Holds details of how to arrange an item between delivery groups
-     */
-    private void updateOrCreateCartItemToCartDeliveryGroup(CartExtension.Cart cart, CartExtension.CartDeliveryGroup targetCartDeliveryGroup, CartExtension.ItemArrange itemArrange) {
-        if (itemArrange.getCartItemId() == null) {
-            CartExtension.CartItem cartItem = new CartExtension.CartItem(CartExtension.SalesItemTypeEnum.PRODUCT, targetCartDeliveryGroup, 'My Cart Item');
-            cartItem.setProduct2Id(itemArrange.getProductId());
-            cartItem.setQuantity(itemArrange.getQuantity());
-            cart.getCartItems().add(cartItem);
-        } else {
-            Iterator<CartExtension.CartItem> cartItemsIterator = cart.getCartItems().iterator();
-            while (cartItemsIterator.hasNext()) {
-                CartExtension.CartItem cartItem = cartItemsIterator.next();
-                if (cartItem.getId() == itemArrange.getCartItemId()) {
-                    if (itemArrange.getQuantity() == 0.0) {
-                        cart.getCartItems().remove(cartItem);
-                    } else {
-                        cartItem.setQuantity(itemArrange.getQuantity());
-                        cartItem.setCartDeliveryGroup(targetCartDeliveryGroup);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * @description Checks whether two addresses are equal.
-     * @param address1 Address 1
-     * @param address2 Address 2
-     */
-    private Boolean areAddressesEqual(Address address1, Address address2) {
-        if (address1 == null && address2 == null) {
-            return true;
-        }
-        if (address1 == null || address2 == null) {
-            return false;
-        }
-        if (address1.getCity() != address2.getCity()) {
-            return false;
-        }
-        if (address1.getCountry() != address2.getCountry()) {
-            return false;
-        }
-        if (address1.getCountryCode() != address2.getCountryCode()) {
-            return false;
-        }
-        if (address1.getGeocodeAccuracy() != address2.getGeocodeAccuracy()) {
-            return false;
-        }
-        if (address1.getPostalCode() != address2.getPostalCode()) {
-            return false;
-        }
-        if (address1.getState() != address2.getState()) {
-            return false;
-        }
-        if (address1.getStateCode() != address2.getStateCode()) {
-            return false;
-        }
-        if (address1.getStreet() != address2.getStreet()) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -1,5 +1,9 @@
 /**
- * @description Custom Split Shipment Service sample.
+ * @description Custom Split Shipment Service that creates Cart Delivery Groups by conveyable and non-conveyable products. <br/>
+ * Products that are non-conveyable cannot go on the conveyor belt at the warehouse because they are too big, bulky, and/or heavy. <br/>
+ * This means that these non-conveyable items may require additional packaging and will take longer to get onto a delivery truck. <br/>
+ * NOTE: A custom checkbox field named 'IsConveyable__c' must be created on the Product2 and CartDeliveryGroup entities in order to <br/>
+ * run this Apex.
  */
 global class SplitShipmentSample extends CartExtension.SplitShipmentService {
 
@@ -43,9 +47,7 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
     }
 
     /**
-     * @description Split up the shipment by conveyable and non-conveyable products. Products that are non-conveyable
-     * cannot go on the conveyor belt at the warehouse because they are too big, bulky, and/or heavy. This means that
-     * these non-conveyable items may require additional packaging and will take longer to get onto a delivery truck.
+     * @description Split up the shipment by conveyable and non-conveyable products.
      * @param cart Holds details about a Cart
      * @param itemArrange Holds information on how the item should be arranged
      */

--- a/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentSample.cls
@@ -5,11 +5,40 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
 
     public virtual override void arrangeItems(CartExtension.ItemArrangementRequest request) {
         CartExtension.Cart cart = request.getCart();
+        Iterator<CartExtension.ItemArrange> itemArrangeIterator = request.getItemArrangeList().iterator();
 
-        Iterator<CartExtension.ItemArrange> iterator = request.getItemArrangeList().iterator();
-        while (iterator.hasNext()) {
-            CartExtension.ItemArrange itemArrange = iterator.next();
-            arrangeItemsByProductConveyability(cart, itemArrange);
+        // Get all productIds from the ItemArrange list
+        List<Id> productIds = new List<Id>();
+        while (itemArrangeIterator.hasNext()) {
+            CartExtension.ItemArrange itemArrange = itemArrangeIterator.next();
+            productIds.add(itemArrange.getProductId());
+        }
+
+        // Get conveyability info for each product
+        List<Product2> products = [
+            SELECT
+                Id
+                , IsConveyable__c
+            FROM Product2
+            WHERE Id IN :productIds
+        ];
+        Iterator<Product2> productsIterator = products.iterator();
+
+        Map<Id,Boolean> productConveyability = new Map<Id,Boolean>();
+        while (productsIterator.hasNext()) {
+            Product2 product = productsIterator.next();
+            productConveyability.put(product.Id, product.IsConveyable__c);
+        }
+
+        // Arrange items by conveyability
+        itemArrangeIterator = request.getItemArrangeList().iterator();
+        while (itemArrangeIterator.hasNext()) {
+            CartExtension.ItemArrange itemArrange = itemArrangeIterator.next();
+
+            // If the item is non-conveyable, then move it to a non-conveyable CartDeliveryGroup
+            if (productConveyability.get(itemArrange.getProductId()) != true) {
+                arrangeNonConveyableItem(cart, itemArrange);
+            }
         }
     }
 
@@ -20,24 +49,17 @@ global class SplitShipmentSample extends CartExtension.SplitShipmentService {
      * @param cart Holds details about a Cart
      * @param itemArrange Holds information on how the item should be arranged
      */
-    private void arrangeItemsByProductConveyability(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
-        // Get conveyable info for the product
-        List<Product2> products = [SELECT IsConveyable__c FROM Product2 WHERE Id =: itemArrange.getProductId() LIMIT 1];
-        Boolean isConveyable = Boolean.valueOf(products[0].IsConveyable__c);
+    private void arrangeNonConveyableItem(CartExtension.Cart cart, CartExtension.ItemArrange itemArrange) {
+        // Check to see if we already have a CartDeliveryGroup for non-conveyable items
+        CartExtension.CartDeliveryGroup nonConveyableCartDeliveryGroup = findNonConveyableCartDeliveryGroup(cart);
 
-        // If the product is non-conveyable, then we need to move the item to a non-conveyable CartDeliveryGroup
-        if (!isConveyable) {
-            // Check to see if we already have a CartDeliveryGroup for non-conveyable items
-            CartExtension.CartDeliveryGroup nonConveyableCartDeliveryGroup = findNonConveyableCartDeliveryGroup(cart);
-
-            if (nonConveyableCartDeliveryGroup == null) {
-                // Create a CartDeliveryGroup for items that are non-conveyable
-                nonConveyableCartDeliveryGroup = createNonConveyableCartDeliveryGroup(cart, itemArrange);
-            }
-
-            // Move the non-conveyable CartItem to the non-conveyable CartDeliveryGroup
-            moveCartItemToTargetCartDeliveryGroup(cart, itemArrange, nonConveyableCartDeliveryGroup);
+        if (nonConveyableCartDeliveryGroup == null) {
+            // Create a CartDeliveryGroup for items that are non-conveyable
+            nonConveyableCartDeliveryGroup = createNonConveyableCartDeliveryGroup(cart, itemArrange);
         }
+
+        // Move the non-conveyable CartItem to the non-conveyable CartDeliveryGroup
+        moveCartItemToTargetCartDeliveryGroup(cart, itemArrange, nonConveyableCartDeliveryGroup);
     }
 
     /**

--- a/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
@@ -28,7 +28,7 @@ global class SplitShipmentUnitTest {
         CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
 
         // Create item arrangement request
-        CartExtension.ItemArrange itemArrange = createItemArrange(cart.getCartItems().get(0).getId(), null);
+        CartExtension.ItemArrange itemArrange = createItemArrange(cart.getCartItems().get(0).getId(), null, null);
         List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
         itemArrangeList.add(itemArrange);
 
@@ -59,8 +59,11 @@ global class SplitShipmentUnitTest {
         // Create a Cart with CHECKOUT status
         Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
 
+        // Create a default Cart Delivery Group
+        Id defaultCartDeliveryGroupId = createDefaultCartDeliveryGroup(cartId);
+
         // Associate 3 items to the Cart
-        Map<ID, ID> cartItemIdToProductIdMap = addThreeItemsToCart(cartId);
+        Map<ID, ID> cartItemIdToProductIdMap = addThreeItemsToCart(cartId, defaultCartDeliveryGroupId);
 
         // Load the Cart
         CartExtension.Cart cart = CartExtension.CartTestUtil.getCart(cartId);
@@ -68,7 +71,7 @@ global class SplitShipmentUnitTest {
         // Create item arrangement request
         List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
         for (ID cartItemId : cartItemIdToProductIdMap.keySet()) {
-            itemArrangeList.add(createItemArrange(cartItemId, cartItemIdToProductIdMap.get(cartItemId)));
+            itemArrangeList.add(createItemArrange(cartItemId, null, cartItemIdToProductIdMap.get(cartItemId)));
         }
 
         CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
@@ -129,16 +132,31 @@ global class SplitShipmentUnitTest {
     }
 
     /**
+     * @description Set up the default CartDeliveryGroup and configure it such that it is meant only for conveyable products.
+     * @param cartId ID of the WebCart that needs to be associated to the CartDeliveryGroup
+     *
+     * @return ID The ID of the newly created CartDeliveryGroup
+     */
+    private static ID createDefaultCartDeliveryGroup(ID cartId) {
+        CartDeliveryGroup deliveryGroup = new CartDeliveryGroup(
+            Name = DELIVERYGROUP_NAME,
+            DeliverToName = 'Rob Gronkowski',
+            IsDefault = true,
+            CartId = cartId,
+            IsConveyable__c = true);
+        insert deliveryGroup;
+
+        return deliveryGroup.Id;
+    }
+
+    /**
      * @description Add three items to the specified Cart.
      * @param cartId ID of the WebCart for which we need to add three items
+     * @param deliveryGroupId ID of the CartDeliveryGroup
      *
      * @return Map CartItemIds that were added, along with their associated ProductId
      */
-    private static Map<ID, ID> addThreeItemsToCart(ID cartId) {
-        // Set up the default CartDeliveryGroup and configure it such that it is meant only for conveyable products
-        CartDeliveryGroup deliveryGroup = new CartDeliveryGroup(Name = DELIVERYGROUP_NAME, CartId = cartId, IsConveyable__c = true);
-        insert deliveryGroup;
-
+    private static Map<ID, ID> addThreeItemsToCart(ID cartId, ID deliveryGroupId) {
         // Configure the first product as non-conveyable
         Product2 testProduct1 = new Product2(name='My Product 1', IsConveyable__c = false);
         insert(testProduct1);
@@ -146,7 +164,7 @@ global class SplitShipmentUnitTest {
         CartItem cartItem1 = new CartItem(
                 Name = CART_ITEM1_NAME,
                 CartId = cartId,
-                CartDeliveryGroupId = deliveryGroup.Id,
+                CartDeliveryGroupId = deliveryGroupId,
                 Quantity = 10.0,
                 SKU = SKU1_NAME,
                 Product2Id=testProduct1.Id,
@@ -160,7 +178,7 @@ global class SplitShipmentUnitTest {
         CartItem cartItem2 = new CartItem(
                 Name = CART_ITEM2_NAME,
                 CartId = cartId,
-                CartDeliveryGroupId = deliveryGroup.Id,
+                CartDeliveryGroupId = deliveryGroupId,
                 Quantity = 2.0,
                 SKU = SKU2_NAME,
                 Product2Id=testProduct2.Id,
@@ -174,7 +192,7 @@ global class SplitShipmentUnitTest {
         CartItem cartItem3 = new CartItem(
                 Name = CART_ITEM3_NAME,
                 CartId = cartId,
-                CartDeliveryGroupId = deliveryGroup.Id,
+                CartDeliveryGroupId = deliveryGroupId,
                 Quantity = 5.0,
                 SKU = SKU3_NAME,
                 Product2Id=testProduct3.Id,
@@ -188,24 +206,32 @@ global class SplitShipmentUnitTest {
     /**
      * @description Create an ItemArrange object, provided the cartItemId and quantity
      * @param cartItemId ID of the CartItem
+     * @param deliveryGroupId ID of the CartDeliveryGroup
      * @param productId ID of the Product2
      *
      * @return CartExtension.ItemArrange Holds details of how to arrange an item between CartDeliveryGroups
      */
-    private static CartExtension.ItemArrange createItemArrange(ID cartItemId, ID productId) {
-        return new CartExtension.ItemArrange.Builder()
-                .withCartItemId(cartItemId)
-                .withProductId(productId)
+    private static CartExtension.ItemArrange createItemArrange(ID cartItemId, ID deliveryGroupId, ID productId) {
+        CartExtension.ItemArrange.Builder builder = new CartExtension.ItemArrange.Builder()
+            .withCartItemId(cartItemId)
+            .withProductId(productId);
+
+        if (deliveryGroupId != null) {
+            builder.withDeliveryGroupId(deliveryGroupId);
+        } else {
+            builder
                 .withDeliverToCity('Foxborough')
                 .withDeliverToCountry('United States')
                 .withDeliverFromFirstName('Tom')
                 .withDeliverFromLastName('Brady')
-                .withDeliverToName('Bill Belichick')
+                .withDeliverToName('Rob Gronkowski')
                 .withDeliverToPostalCode('02035')
                 .withDeliverToState('Massachusetts')
                 .withDeliverToStreet('2 Patriot Place')
-                .withDeliverToCompanyName('New England Patriots')
-                .build();
+                .withDeliverToCompanyName('New England Patriots');
+        }
+
+        return builder.build();
     }
 
     global class MockDefaultSplitShipmentService extends CartExtension.SplitShipmentServiceMock {

--- a/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
@@ -9,21 +9,26 @@ global class SplitShipmentUnitTest {
     private static final String DELIVERYGROUP_NAME = 'Default Delivery Group';
     private static final String CART_ITEM1_NAME = 'My Cart Item 1';
     private static final String CART_ITEM2_NAME = 'My Cart Item 2';
+    private static final String CART_ITEM3_NAME = 'My Cart Item 3';
     private static final String SKU1_NAME = 'My SKU 1';
     private static final String SKU2_NAME = 'My SKU 2';
+    private static final String SKU3_NAME = 'My SKU 3';
 
     private static final MockDefaultSplitShipmentService mockService = new MockDefaultSplitShipmentService();
     private static final SplitShipmentCallsSuper splitShipmentCallsSuper = new SplitShipmentCallsSuper(mockService);
     private static final SplitShipmentSample splitShipmentSample = new SplitShipmentSample();
 
+    /**
+     * @description Verify that SplitShipmentService invoked the default implementation.
+     */
     @IsTest
-    public static void splitShipmentApexThatCallsSuperShouldInvokeDefaultSplitShipmentService() {
+    public static void splitShipmentServiceShouldCallDefaultImplementation() {
         // Arrange
         // Create a Cart
         CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
 
-        // Arrange CartItem1 such that a CartDeliveryGroup can have at most quantity 5 of this particular CartItem
-        CartExtension.ItemArrange itemArrange = createItemArrange(cart.getCartItems().get(0).getId(), 5.0);
+        // Create item arrangement request
+        CartExtension.ItemArrange itemArrange = createItemArrange(cart.getCartItems().get(0).getId(), null);
         List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
         itemArrangeList.add(itemArrange);
 
@@ -42,33 +47,36 @@ global class SplitShipmentUnitTest {
         Assert.isTrue(cart.getName().contains('Default Split Shipment Service was invoked'));
     }
 
+    /**
+     * @description Verify that SplitShipmentService arranged CartItems by a "Product Conveyability" custom field.
+     * The 'IsConveyable__c' custom checkbox field on Product2 signifies if the product can go on the conveyer belt
+     * at a warehouse. Items that cannot go on the conveyer belt may be big, bulky, and/or heavy which may require
+     * additional packaging and will take longer to get onto a delivery truck.
+     */
     @IsTest
-    public static void splitShipmentApexShouldNotCreateNewDeliveryGroupsBasedOnCartItemQuantity() {
+    public static void splitShipmentServiceShouldCreateDeliveryGroupBasedOnConveyability() {
         // Arrange
         // Create a Cart with CHECKOUT status
         Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
 
-        // Associate 2 CartItems with the specified quantities to the Cart
-        Decimal cartItem1Quantity = 100.0;
-        Decimal cartItem2Quantity = 2.0;
-        List<ID> Ids = addTwoItemsToCart(cartId, cartItem1Quantity, cartItem2Quantity);
+        // Associate 3 items to the Cart
+        Map<ID, ID> cartItemIdToProductIdMap = addThreeItemsToCart(cartId);
 
+        // Load the Cart
         CartExtension.Cart cart = CartExtension.CartTestUtil.getCart(cartId);
 
-        // Arrange CartItem1 such that a CartDeliveryGroup can have at most quantity 100 of this particular CartItem
-        CartExtension.ItemArrange itemArrange1 = createItemArrange(Ids[0], 100.0);
-
-        // Arrange CartItem2 such that a CartDeliveryGroup can have at most quantity 10 of this particular CartItem
-        CartExtension.ItemArrange itemArrange2 = createItemArrange(Ids[1], 10.0);
-
+        // Create item arrangement request
         List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange1);
-        itemArrangeList.add(itemArrange2);
+        for (ID cartItemId : cartItemIdToProductIdMap.keySet()) {
+            itemArrangeList.add(createItemArrange(cartItemId, cartItemIdToProductIdMap.get(cartItemId)));
+        }
 
         CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
                 .withCart(cart)
                 .withItemArrangeList(itemArrangeList)
                 .build();
+
+        final String expectedNonConveyableCartDeliveryGroupName = 'Non-Conveyable Cart Delivery Group';
 
         // Act
         Test.startTest();
@@ -76,70 +84,25 @@ global class SplitShipmentUnitTest {
         Test.stopTest();
 
         // Assert
-        // Verify that no new CartDeliveryGroup was created
-        Assert.areEqual(1, cart.getCartDeliveryGroups().size());
+        // Verify that we have 2 CartDeliveryGroups, since a non-conveyable CartDeliveryGroup should have been created
+        Assert.areEqual(2, cart.getCartDeliveryGroups().size());
+        Assert.areEqual(DELIVERYGROUP_NAME, cart.getCartDeliveryGroups().get(0).getName());
+        Assert.areEqual(expectedNonConveyableCartDeliveryGroupName, cart.getCartDeliveryGroups().get(1).getName());
 
-        // Verify that no new CartItems were created and that the original CartItems were kept as is
-        Assert.areEqual(2, cart.getCartItems().size());
-        Assert.areEqual(cartItem1Quantity, cart.getCartItems().get(0).getQuantity());
+        // Verify that no new CartItems were created
+        Assert.areEqual(3, cart.getCartItems().size());
+
+        // Verify that the first CartItem was moved to the non-conveyable CartDeliveryGroup
         Assert.areEqual(CART_ITEM1_NAME, cart.getCartItems().get(0).getName());
-        Assert.areEqual(cartItem2Quantity, cart.getCartItems().get(1).getQuantity());
+        Assert.areEqual(expectedNonConveyableCartDeliveryGroupName, cart.getCartItems().get(0).getCartDeliveryGroup().getName());
+
+        // Verify that the second CartItem remained in the original, default CartDeliveryGroup
         Assert.areEqual(CART_ITEM2_NAME, cart.getCartItems().get(1).getName());
-    }
+        Assert.areEqual(DELIVERYGROUP_NAME, cart.getCartItems().get(1).getCartDeliveryGroup().getName());
 
-    @IsTest
-    public static void splitShipmentApexShouldCreateNewDeliveryGroupsBasedOnCartItemQuantity() {
-        // Arrange
-        // Create a Cart with CHECKOUT status
-        Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
-
-        // Associate 2 CartItems with the specified quantities to the Cart
-        Decimal cartItem1Quantity = 100.0;
-        Decimal cartItem2Quantity = 2.0;
-        List<ID> Ids = addTwoItemsToCart(cartId, cartItem1Quantity, cartItem2Quantity);
-
-        CartExtension.Cart cart = CartExtension.CartTestUtil.getCart(cartId);
-
-        // Arrange CartItem1 such that a CartDeliveryGroup can have at most quantity 45 of this particular CartItem
-        CartExtension.ItemArrange itemArrange1 = createItemArrange(Ids[0], 45.0);
-
-        // Arrange CartItem2 such that a CartDeliveryGroup can have at most quantity 10 of this particular CartItem
-        CartExtension.ItemArrange itemArrange2 = createItemArrange(Ids[1], 10.0);
-
-        List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange1);
-        itemArrangeList.add(itemArrange2);
-
-        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
-                .withCart(cart)
-                .withItemArrangeList(itemArrangeList)
-                .build();
-
-        // Act
-        Test.startTest();
-        splitShipmentSample.arrangeItems(request);
-        Test.stopTest();
-
-        // Assert
-        // Verify that 2 new CartDeliveryGroups were created (totaling 3)
-        Assert.areEqual(3, cart.getCartDeliveryGroups().size());
-
-        // Verify that 2 new CartItems were created (totaling 4)
-        Assert.areEqual(4, cart.getCartItems().size());
-
-        // Verify that the quantity for the (original) CartItem1 was reduced from 100.0 to 45.0
-        Assert.areEqual(45.0, cart.getCartItems().get(0).getQuantity());
-        Assert.areEqual(CART_ITEM1_NAME, cart.getCartItems().get(0).getName());
-
-        // Verify that the quantity for CartItem2 remained the same
-        Assert.areEqual(cartItem2Quantity, cart.getCartItems().get(1).getQuantity());
-        Assert.areEqual(CART_ITEM2_NAME, cart.getCartItems().get(1).getName());
-
-        // Verify that new CartItems were created to account for the remaining quantity from the original CartItem1
-        Assert.areEqual(45.0, cart.getCartItems().get(2).getQuantity());
-        Assert.areEqual('My Cart Item 3', cart.getCartItems().get(2).getName());
-        Assert.areEqual(10.0, cart.getCartItems().get(3).getQuantity());
-        Assert.areEqual('My Cart Item 4', cart.getCartItems().get(3).getName());
+        // Verify that the third CartItem was also moved to the non-conveyable CartDeliveryGroup
+        Assert.areEqual(CART_ITEM3_NAME, cart.getCartItems().get(2).getName());
+        Assert.areEqual(expectedNonConveyableCartDeliveryGroupName, cart.getCartItems().get(2).getCartDeliveryGroup().getName());
     }
 
     /**
@@ -166,49 +129,73 @@ global class SplitShipmentUnitTest {
     }
 
     /**
-     * @description Add two items with the specified quantities to the WebCart.
-     * @param cartId ID of the WebCart for which we need to add two items
-     * @param cartItem1Quantity Quantity of the first CartItem
-     * @param cartItem2Quantity Quantity of the second CartItem
+     * @description Add three items to the specified Cart.
+     * @param cartId ID of the WebCart for which we need to add three items
      *
-     * @return List IDs associated to the newly added CartItems
+     * @return Map CartItemIds that were added, along with their associated ProductId
      */
-    private static List<ID> addTwoItemsToCart(ID cartId, Decimal cartItem1Quantity, Decimal cartItem2Quantity) {
-        CartDeliveryGroup deliveryGroup = new CartDeliveryGroup(Name = DELIVERYGROUP_NAME, CartId = cartId);
+    private static Map<ID, ID> addThreeItemsToCart(ID cartId) {
+        // Set up the default CartDeliveryGroup and configure it such that it is meant only for conveyable products
+        CartDeliveryGroup deliveryGroup = new CartDeliveryGroup(Name = DELIVERYGROUP_NAME, CartId = cartId, IsConveyable__c = true);
         insert deliveryGroup;
+
+        // Configure the first product as non-conveyable
+        Product2 testProduct1 = new Product2(name='My Product 1', IsConveyable__c = false);
+        insert(testProduct1);
 
         CartItem cartItem1 = new CartItem(
                 Name = CART_ITEM1_NAME,
                 CartId = cartId,
                 CartDeliveryGroupId = deliveryGroup.Id,
-                Quantity = cartItem1Quantity,
+                Quantity = 10.0,
                 SKU = SKU1_NAME,
+                Product2Id=testProduct1.Id,
                 Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
         insert cartItem1;
+
+        // Configure the second product as conveyable
+        Product2 testProduct2 = new Product2(name='My Product 2', IsConveyable__c = true);
+        insert(testProduct2);
 
         CartItem cartItem2 = new CartItem(
                 Name = CART_ITEM2_NAME,
                 CartId = cartId,
                 CartDeliveryGroupId = deliveryGroup.Id,
-                Quantity = cartItem2Quantity,
+                Quantity = 2.0,
                 SKU = SKU2_NAME,
+                Product2Id=testProduct2.Id,
                 Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
         insert cartItem2;
 
-        return new List<ID>{ cartItem1.Id, cartItem2.Id };
+        // Configure the third product as non-conveyable
+        Product2 testProduct3 = new Product2(name='My Product 3', IsConveyable__c = false);
+        insert(testProduct3);
+
+        CartItem cartItem3 = new CartItem(
+                Name = CART_ITEM3_NAME,
+                CartId = cartId,
+                CartDeliveryGroupId = deliveryGroup.Id,
+                Quantity = 5.0,
+                SKU = SKU3_NAME,
+                Product2Id=testProduct3.Id,
+                Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
+        insert cartItem3;
+
+        // Return a map where the key -> value is: CartItemId -> ProductId
+        return new Map<ID, ID>{ cartItem1.Id => testProduct1.Id, cartItem2.Id => testProduct2.Id, cartItem3.Id => testProduct3.Id };
     }
 
     /**
      * @description Create an ItemArrange object, provided the cartItemId and quantity
      * @param cartItemId ID of the CartItem
-     * @param quantity Maximum quantity that a CartDeliveryGroup can have for this particular CartItem
+     * @param productId ID of the Product2
      *
      * @return CartExtension.ItemArrange Holds details of how to arrange an item between CartDeliveryGroups
      */
-    private static CartExtension.ItemArrange createItemArrange(ID cartItemId, Decimal quantity) {
+    private static CartExtension.ItemArrange createItemArrange(ID cartItemId, ID productId) {
         return new CartExtension.ItemArrange.Builder()
                 .withCartItemId(cartItemId)
-                .withQuantity(quantity)
+                .withProductId(productId)
                 .withDeliverToCity('Foxborough')
                 .withDeliverToCountry('United States')
                 .withDeliverFromFirstName('Tom')

--- a/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
@@ -3,6 +3,14 @@
  */
 @IsTest
 global class SplitShipmentUnitTest {
+    private static final String CART_NAME = 'My Cart';
+    private static final String ACCOUNT_NAME = 'My Account';
+    private static final String WEBSTORE_NAME = 'My WebStore';
+    private static final String DELIVERYGROUP_NAME = 'Default Delivery Group';
+    private static final String CART_ITEM1_NAME = 'My Cart Item 1';
+    private static final String CART_ITEM2_NAME = 'My Cart Item 2';
+    private static final String SKU1_NAME = 'My SKU 1';
+    private static final String SKU2_NAME = 'My SKU 2';
 
     private static final MockDefaultSplitShipmentService mockService = new MockDefaultSplitShipmentService();
     private static final SplitShipmentCallsSuper splitShipmentCallsSuper = new SplitShipmentCallsSuper(mockService);
@@ -11,27 +19,12 @@ global class SplitShipmentUnitTest {
     @IsTest
     public static void splitShipmentApexThatCallsSuperShouldInvokeDefaultSplitShipmentService() {
         // Arrange
+        // Create a Cart
         CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
 
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withProductId('01txx0000006iP2AAI')
-                .withQuantity(Decimal.valueOf(5))
-                .withCartItemId(cart.getCartItems().get(0).getId())
-                .withDeliveryGroupId(cart.getCartItems().get(0).getCartDeliveryGroup().getId())
-                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
-                .withDeliverToCity('Foxboro')
-                .withDeliverToCountry('USA')
-                .withDeliverFromFirstName('Tom')
-                .withDeliverFromLastName('Brady')
-                .withDeliverToName('Bill Belichick')
-                .withDeliverToPostalCode('02035')
-                .withDeliverToState('MA')
-                .withDeliverToStreet('2 Patriot Place')
-                .withDeliverToCompanyName('New England Patriots')
-                .withDeliveryAddressId('8lW456789012679AAA')
-                .build();
-
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        // Arrange CartItem1 such that a CartDeliveryGroup can have at most quantity 5 of this particular CartItem
+        CartExtension.ItemArrange itemArrange = createItemArrange(cart.getCartItems().get(0).getId(), 5.0);
+        List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
         itemArrangeList.add(itemArrange);
 
         CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
@@ -40,25 +33,37 @@ global class SplitShipmentUnitTest {
                 .build();
 
         // Act
+        Test.startTest();
         splitShipmentCallsSuper.arrangeItems(request);
+        Test.stopTest();
 
         // Assert
+        // Verify that the default implementation was called
         Assert.isTrue(cart.getName().contains('Default Split Shipment Service was invoked'));
     }
 
     @IsTest
-    public static void splitShipmentApexWithDeliveryGroupIdAndProductId() {
+    public static void splitShipmentApexShouldNotCreateNewDeliveryGroupsBasedOnCartItemQuantity() {
         // Arrange
-        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+        // Create a Cart with CHECKOUT status
+        Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
 
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withProductId('01txx0000006iP2AAI')
-                .withQuantity(Decimal.valueOf(5))
-                .withDeliveryGroupId(cart.getCartItems().get(0).getCartDeliveryGroup().getId())
-                .build();
+        // Associate 2 CartItems with the specified quantities to the Cart
+        Decimal cartItem1Quantity = 100.0;
+        Decimal cartItem2Quantity = 2.0;
+        List<ID> Ids = addTwoItemsToCart(cartId, cartItem1Quantity, cartItem2Quantity);
 
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange);
+        CartExtension.Cart cart = CartExtension.CartTestUtil.getCart(cartId);
+
+        // Arrange CartItem1 such that a CartDeliveryGroup can have at most quantity 100 of this particular CartItem
+        CartExtension.ItemArrange itemArrange1 = createItemArrange(Ids[0], 100.0);
+
+        // Arrange CartItem2 such that a CartDeliveryGroup can have at most quantity 10 of this particular CartItem
+        CartExtension.ItemArrange itemArrange2 = createItemArrange(Ids[1], 10.0);
+
+        List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange1);
+        itemArrangeList.add(itemArrange2);
 
         CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
                 .withCart(cart)
@@ -66,27 +71,44 @@ global class SplitShipmentUnitTest {
                 .build();
 
         // Act
+        Test.startTest();
         splitShipmentSample.arrangeItems(request);
+        Test.stopTest();
 
         // Assert
-        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
-        Assert.isTrue(cart.getCartItems().size() == 2);
-        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
+        // Verify that no new CartDeliveryGroup was created
+        Assert.areEqual(1, cart.getCartDeliveryGroups().size());
+
+        // Verify that no new CartItems were created and that the original CartItems were kept as is
+        Assert.areEqual(2, cart.getCartItems().size());
+        Assert.areEqual(cartItem1Quantity, cart.getCartItems().get(0).getQuantity());
+        Assert.areEqual(CART_ITEM1_NAME, cart.getCartItems().get(0).getName());
+        Assert.areEqual(cartItem2Quantity, cart.getCartItems().get(1).getQuantity());
+        Assert.areEqual(CART_ITEM2_NAME, cart.getCartItems().get(1).getName());
     }
 
     @IsTest
-    public static void splitShipmentApexWithDeliveryGroupIdAndCartItemId() {
+    public static void splitShipmentApexShouldCreateNewDeliveryGroupsBasedOnCartItemQuantity() {
         // Arrange
-        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+        // Create a Cart with CHECKOUT status
+        Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
 
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withCartItemId(cart.getCartItems().get(0).getId())
-                .withQuantity(Decimal.valueOf(5))
-                .withDeliveryGroupId(cart.getCartItems().get(0).getCartDeliveryGroup().getId())
-                .build();
+        // Associate 2 CartItems with the specified quantities to the Cart
+        Decimal cartItem1Quantity = 100.0;
+        Decimal cartItem2Quantity = 2.0;
+        List<ID> Ids = addTwoItemsToCart(cartId, cartItem1Quantity, cartItem2Quantity);
 
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange);
+        CartExtension.Cart cart = CartExtension.CartTestUtil.getCart(cartId);
+
+        // Arrange CartItem1 such that a CartDeliveryGroup can have at most quantity 45 of this particular CartItem
+        CartExtension.ItemArrange itemArrange1 = createItemArrange(Ids[0], 45.0);
+
+        // Arrange CartItem2 such that a CartDeliveryGroup can have at most quantity 10 of this particular CartItem
+        CartExtension.ItemArrange itemArrange2 = createItemArrange(Ids[1], 10.0);
+
+        List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange1);
+        itemArrangeList.add(itemArrange2);
 
         CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
                 .withCart(cart)
@@ -94,205 +116,111 @@ global class SplitShipmentUnitTest {
                 .build();
 
         // Act
+        Test.startTest();
         splitShipmentSample.arrangeItems(request);
+        Test.stopTest();
 
         // Assert
-        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
-        Assert.isTrue(cart.getCartItems().size() == 1);
-        Assert.isTrue(cart.getCartItems().get(0).getQuantity() == 5.0);
+        // Verify that 2 new CartDeliveryGroups were created (totaling 3)
+        Assert.areEqual(3, cart.getCartDeliveryGroups().size());
+
+        // Verify that 2 new CartItems were created (totaling 4)
+        Assert.areEqual(4, cart.getCartItems().size());
+
+        // Verify that the quantity for the (original) CartItem1 was reduced from 100.0 to 45.0
+        Assert.areEqual(45.0, cart.getCartItems().get(0).getQuantity());
+        Assert.areEqual(CART_ITEM1_NAME, cart.getCartItems().get(0).getName());
+
+        // Verify that the quantity for CartItem2 remained the same
+        Assert.areEqual(cartItem2Quantity, cart.getCartItems().get(1).getQuantity());
+        Assert.areEqual(CART_ITEM2_NAME, cart.getCartItems().get(1).getName());
+
+        // Verify that new CartItems were created to account for the remaining quantity from the original CartItem1
+        Assert.areEqual(45.0, cart.getCartItems().get(2).getQuantity());
+        Assert.areEqual('My Cart Item 3', cart.getCartItems().get(2).getName());
+        Assert.areEqual(10.0, cart.getCartItems().get(3).getQuantity());
+        Assert.areEqual('My Cart Item 4', cart.getCartItems().get(3).getName());
     }
 
-    @IsTest
-    public static void splitShipmentApexWithAddressAndProductIdKeepingExistingCDG() {
-        // Arrange
-        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+    /**
+     * @description Create a WebCart with the specific status.
+     * @param cartStatus Status of the Cart
+     *
+     * @return ID of the WebCart
+     */
+    private static ID createCartWithSpecifiedStatus(CartExtension.CartStatusEnum cartStatus) {
+        Account account = new Account(Name = ACCOUNT_NAME);
+        insert account;
 
-        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
-        setAddressFields(cartDeliveryGroup);
+        WebStore webStore = new WebStore(Name = WEBSTORE_NAME);
+        insert webStore;
 
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withProductId('01txx0000006iP2AAI')
-                .withQuantity(Decimal.valueOf(5))
-                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
-                .withDeliverToCity('Foxboro')
-                .withDeliverToCountry('USA')
+        WebCart webCart = new WebCart(
+                Name = CART_NAME,
+                WebStoreId = webStore.Id,
+                AccountId = account.Id,
+                Status = cartStatus.name());
+        insert webCart;
+
+        return webCart.Id;
+    }
+
+    /**
+     * @description Add two items with the specified quantities to the WebCart.
+     * @param cartId ID of the WebCart for which we need to add two items
+     * @param cartItem1Quantity Quantity of the first CartItem
+     * @param cartItem2Quantity Quantity of the second CartItem
+     *
+     * @return List IDs associated to the newly added CartItems
+     */
+    private static List<ID> addTwoItemsToCart(ID cartId, Decimal cartItem1Quantity, Decimal cartItem2Quantity) {
+        CartDeliveryGroup deliveryGroup = new CartDeliveryGroup(Name = DELIVERYGROUP_NAME, CartId = cartId);
+        insert deliveryGroup;
+
+        CartItem cartItem1 = new CartItem(
+                Name = CART_ITEM1_NAME,
+                CartId = cartId,
+                CartDeliveryGroupId = deliveryGroup.Id,
+                Quantity = cartItem1Quantity,
+                SKU = SKU1_NAME,
+                Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
+        insert cartItem1;
+
+        CartItem cartItem2 = new CartItem(
+                Name = CART_ITEM2_NAME,
+                CartId = cartId,
+                CartDeliveryGroupId = deliveryGroup.Id,
+                Quantity = cartItem2Quantity,
+                SKU = SKU2_NAME,
+                Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
+        insert cartItem2;
+
+        return new List<ID>{ cartItem1.Id, cartItem2.Id };
+    }
+
+    /**
+     * @description Create an ItemArrange object, provided the cartItemId and quantity
+     * @param cartItemId ID of the CartItem
+     * @param quantity Maximum quantity that a CartDeliveryGroup can have for this particular CartItem
+     *
+     * @return CartExtension.ItemArrange Holds details of how to arrange an item between CartDeliveryGroups
+     */
+    private static CartExtension.ItemArrange createItemArrange(ID cartItemId, Decimal quantity) {
+        return new CartExtension.ItemArrange.Builder()
+                .withCartItemId(cartItemId)
+                .withQuantity(quantity)
+                .withDeliverToCity('Foxborough')
+                .withDeliverToCountry('United States')
                 .withDeliverFromFirstName('Tom')
                 .withDeliverFromLastName('Brady')
                 .withDeliverToName('Bill Belichick')
                 .withDeliverToPostalCode('02035')
-                .withDeliverToState('MA')
+                .withDeliverToState('Massachusetts')
                 .withDeliverToStreet('2 Patriot Place')
                 .withDeliverToCompanyName('New England Patriots')
                 .build();
-
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange);
-
-        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
-                .withCart(cart)
-                .withItemArrangeList(itemArrangeList)
-                .build();
-
-        // Act
-        splitShipmentSample.arrangeItems(request);
-
-        // Assert
-        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
-        Assert.isTrue(cart.getCartItems().size() == 2);
-        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
-        Assert.isTrue(cart.getCartDeliveryGroups().get(0).getDeliverToAddress().getCity() == 'Foxboro');
     }
 
-    @IsTest
-    public static void splitShipmentApexWithAddressAndProductIdCreatingNewCDG() {
-        // Arrange
-        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
-
-        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
-        setAddressFields(cartDeliveryGroup);
-
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withProductId('01txx0000006iP2AAI')
-                .withQuantity(Decimal.valueOf(5))
-                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
-                .withDeliverToCity('Fremont')
-                .withDeliverToCountry('USA')
-                .withDeliverFromFirstName('Michael')
-                .withDeliverFromLastName('Jackson')
-                .withDeliverToName('Michael Jackson')
-                .withDeliverToPostalCode('94539')
-                .withDeliverToState('CA')
-                .withDeliverToStreet('10 Guy St')
-                .withDeliverToCompanyName('Jackson 5')
-                .build();
-
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange);
-
-        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
-                .withCart(cart)
-                .withItemArrangeList(itemArrangeList)
-                .build();
-
-        // Act
-        splitShipmentSample.arrangeItems(request);
-
-        // Assert
-        Assert.isTrue(cart.getCartDeliveryGroups().size() == 2);
-        Assert.isTrue(cart.getCartItems().size() == 2);
-        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
-        Assert.isTrue(cart.getCartDeliveryGroups().get(0).getDeliverToAddress().getCity() == 'Foxboro');
-        Assert.isTrue(cart.getCartDeliveryGroups().get(1).getDeliverToAddress().getCity() == 'Fremont');
-    }
-
-    @IsTest
-    public static void splitShipmentApexWithAddressIdAndProductIdCreatingNewCDG() {
-        // Arrange
-        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
-
-        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
-        setAddressFields(cartDeliveryGroup);
-
-        ContactPointAddress contactPointAddress = new ContactPointAddress();
-        insertContactPointAddress(cart, contactPointAddress);
-
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withProductId('01txx0000006iP2AAI')
-                .withQuantity(Decimal.valueOf(5))
-                .withDeliveryGroupName('New Cart Delivery Group')
-                .withDeliveryAddressId(contactPointAddress.Id)
-                .build();
-
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange);
-
-        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
-                .withCart(cart)
-                .withItemArrangeList(itemArrangeList)
-                .build();
-
-        // Act
-        splitShipmentSample.arrangeItems(request);
-
-        // Assert
-        Assert.isTrue(cart.getCartDeliveryGroups().size() == 2);
-        Assert.isTrue(cart.getCartItems().size() == 2);
-        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
-        Assert.isTrue(cart.getCartDeliveryGroups().get(0).getName() == CartExtension.CartTestUtil.DELIVERYGROUP_NAME);
-        Assert.isTrue(cart.getCartDeliveryGroups().get(1).getName() == 'New Cart Delivery Group');
-    }
-
-    @IsTest
-    public static void splitShipmentApexWithAddressIdAndProductIdKeepingExistingCDG() {
-        // Arrange
-        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
-
-        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
-        setAddressFields(cartDeliveryGroup);
-
-        ContactPointAddress contactPointAddress = new ContactPointAddress();
-        insertContactPointAddress(cart, contactPointAddress);
-
-        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
-                .withProductId('01txx0000006iP2AAI')
-                .withQuantity(Decimal.valueOf(5))
-                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
-                .withDeliveryAddressId(contactPointAddress.Id)
-                .build();
-
-		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
-        itemArrangeList.add(itemArrange);
-
-        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
-                .withCart(cart)
-                .withItemArrangeList(itemArrangeList)
-                .build();
-
-        // Act
-        splitShipmentSample.arrangeItems(request);
-
-        // Assert
-        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
-        Assert.isTrue(cart.getCartItems().size() == 2);
-        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
-    }
-
-    /**
-     * @description Set the necessary delivery address fields within the Cart Delivery Group.
-     * @param cartDeliveryGroup The Cart Delivery Group to update 
-     */
-    private static void setAddressFields(CartExtension.CartDeliveryGroup cartDeliveryGroup) {
-        cartDeliveryGroup.setDeliverToCity('Foxboro');
-        cartDeliveryGroup.setDeliverToCountry('USA');
-        cartDeliveryGroup.setDeliverToFirstName('Tom');
-        cartDeliveryGroup.setDeliverToLastName('Brady');
-        cartDeliveryGroup.setDeliverToName('Bill Belichick');
-        cartDeliveryGroup.setDeliverToPostalCode('02035');
-        cartDeliveryGroup.setDeliverToState('MA');
-        cartDeliveryGroup.setDeliverToStreet('2 Patriot Place');
-        cartDeliveryGroup.setCompanyName('New England Patriots');
-    }
-
-    /**
-     * @description Create a new ContactPointAddress record in the DB
-     * @param cart Representation of a `WebCart` record
-     * @param contactPointAddress Contact Point Address record to insert
-     */
-    private static void insertContactPointAddress(CartExtension.Cart cart, ContactPointAddress contactPointAddress) {
-        contactPointAddress.ParentId = cart.getAccountId();
-        contactPointAddress.Name = 'ContactPointAddress';
-        contactPointAddress.Street = '2 Patriot Place';
-        contactPointAddress.City = 'Foxboro';
-        contactPointAddress.Country = 'USA';
-        contactPointAddress.PostalCode = '02035';
-        contactPointAddress.State = 'MA';
-
-        insert contactPointAddress;
-    }
-
-    /**
-     * @description Mock version of Split Shipment Service.
-     */
     global class MockDefaultSplitShipmentService extends CartExtension.SplitShipmentServiceMock {
 
         global override void arrangeItems(CartExtension.ItemArrangementRequest request) {

--- a/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
+++ b/commerce/domain/shipping/splitshipment/SplitShipmentUnitTest.cls
@@ -1,0 +1,303 @@
+/**
+ * @description Sample unit test for SplitShipmentSample and SplitShipmentCallsSuper.
+ */
+@IsTest
+global class SplitShipmentUnitTest {
+
+    private static final MockDefaultSplitShipmentService mockService = new MockDefaultSplitShipmentService();
+    private static final SplitShipmentCallsSuper splitShipmentCallsSuper = new SplitShipmentCallsSuper(mockService);
+    private static final SplitShipmentSample splitShipmentSample = new SplitShipmentSample();
+
+    @IsTest
+    public static void splitShipmentApexThatCallsSuperShouldInvokeDefaultSplitShipmentService() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withProductId('01txx0000006iP2AAI')
+                .withQuantity(Decimal.valueOf(5))
+                .withCartItemId(cart.getCartItems().get(0).getId())
+                .withDeliveryGroupId(cart.getCartItems().get(0).getCartDeliveryGroup().getId())
+                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
+                .withDeliverToCity('Foxboro')
+                .withDeliverToCountry('USA')
+                .withDeliverFromFirstName('Tom')
+                .withDeliverFromLastName('Brady')
+                .withDeliverToName('Bill Belichick')
+                .withDeliverToPostalCode('02035')
+                .withDeliverToState('MA')
+                .withDeliverToStreet('2 Patriot Place')
+                .withDeliverToCompanyName('New England Patriots')
+                .withDeliveryAddressId('8lW456789012679AAA')
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentCallsSuper.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getName().contains('Default Split Shipment Service was invoked'));
+    }
+
+    @IsTest
+    public static void splitShipmentApexWithDeliveryGroupIdAndProductId() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withProductId('01txx0000006iP2AAI')
+                .withQuantity(Decimal.valueOf(5))
+                .withDeliveryGroupId(cart.getCartItems().get(0).getCartDeliveryGroup().getId())
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentSample.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
+        Assert.isTrue(cart.getCartItems().size() == 2);
+        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
+    }
+
+    @IsTest
+    public static void splitShipmentApexWithDeliveryGroupIdAndCartItemId() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withCartItemId(cart.getCartItems().get(0).getId())
+                .withQuantity(Decimal.valueOf(5))
+                .withDeliveryGroupId(cart.getCartItems().get(0).getCartDeliveryGroup().getId())
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentSample.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
+        Assert.isTrue(cart.getCartItems().size() == 1);
+        Assert.isTrue(cart.getCartItems().get(0).getQuantity() == 5.0);
+    }
+
+    @IsTest
+    public static void splitShipmentApexWithAddressAndProductIdKeepingExistingCDG() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
+        setAddressFields(cartDeliveryGroup);
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withProductId('01txx0000006iP2AAI')
+                .withQuantity(Decimal.valueOf(5))
+                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
+                .withDeliverToCity('Foxboro')
+                .withDeliverToCountry('USA')
+                .withDeliverFromFirstName('Tom')
+                .withDeliverFromLastName('Brady')
+                .withDeliverToName('Bill Belichick')
+                .withDeliverToPostalCode('02035')
+                .withDeliverToState('MA')
+                .withDeliverToStreet('2 Patriot Place')
+                .withDeliverToCompanyName('New England Patriots')
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentSample.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
+        Assert.isTrue(cart.getCartItems().size() == 2);
+        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
+        Assert.isTrue(cart.getCartDeliveryGroups().get(0).getDeliverToAddress().getCity() == 'Foxboro');
+    }
+
+    @IsTest
+    public static void splitShipmentApexWithAddressAndProductIdCreatingNewCDG() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
+        setAddressFields(cartDeliveryGroup);
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withProductId('01txx0000006iP2AAI')
+                .withQuantity(Decimal.valueOf(5))
+                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
+                .withDeliverToCity('Fremont')
+                .withDeliverToCountry('USA')
+                .withDeliverFromFirstName('Michael')
+                .withDeliverFromLastName('Jackson')
+                .withDeliverToName('Michael Jackson')
+                .withDeliverToPostalCode('94539')
+                .withDeliverToState('CA')
+                .withDeliverToStreet('10 Guy St')
+                .withDeliverToCompanyName('Jackson 5')
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentSample.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getCartDeliveryGroups().size() == 2);
+        Assert.isTrue(cart.getCartItems().size() == 2);
+        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
+        Assert.isTrue(cart.getCartDeliveryGroups().get(0).getDeliverToAddress().getCity() == 'Foxboro');
+        Assert.isTrue(cart.getCartDeliveryGroups().get(1).getDeliverToAddress().getCity() == 'Fremont');
+    }
+
+    @IsTest
+    public static void splitShipmentApexWithAddressIdAndProductIdCreatingNewCDG() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
+        setAddressFields(cartDeliveryGroup);
+
+        ContactPointAddress contactPointAddress = new ContactPointAddress();
+        insertContactPointAddress(cart, contactPointAddress);
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withProductId('01txx0000006iP2AAI')
+                .withQuantity(Decimal.valueOf(5))
+                .withDeliveryGroupName('New Cart Delivery Group')
+                .withDeliveryAddressId(contactPointAddress.Id)
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentSample.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getCartDeliveryGroups().size() == 2);
+        Assert.isTrue(cart.getCartItems().size() == 2);
+        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
+        Assert.isTrue(cart.getCartDeliveryGroups().get(0).getName() == CartExtension.CartTestUtil.DELIVERYGROUP_NAME);
+        Assert.isTrue(cart.getCartDeliveryGroups().get(1).getName() == 'New Cart Delivery Group');
+    }
+
+    @IsTest
+    public static void splitShipmentApexWithAddressIdAndProductIdKeepingExistingCDG() {
+        // Arrange
+        CartExtension.Cart cart = CartExtension.CartTestUtil.createCart();
+
+        CartExtension.CartDeliveryGroup cartDeliveryGroup = cart.getCartDeliveryGroups().get(0);
+        setAddressFields(cartDeliveryGroup);
+
+        ContactPointAddress contactPointAddress = new ContactPointAddress();
+        insertContactPointAddress(cart, contactPointAddress);
+
+        CartExtension.ItemArrange itemArrange = new CartExtension.ItemArrange.Builder()
+                .withProductId('01txx0000006iP2AAI')
+                .withQuantity(Decimal.valueOf(5))
+                .withDeliveryGroupName(CartExtension.CartTestUtil.DELIVERYGROUP_NAME)
+                .withDeliveryAddressId(contactPointAddress.Id)
+                .build();
+
+		List<CartExtension.ItemArrange> itemArrangeList = new List<CartExtension.ItemArrange>();
+        itemArrangeList.add(itemArrange);
+
+        CartExtension.ItemArrangementRequest request = new CartExtension.ItemArrangementRequest.Builder()
+                .withCart(cart)
+                .withItemArrangeList(itemArrangeList)
+                .build();
+
+        // Act
+        splitShipmentSample.arrangeItems(request);
+
+        // Assert
+        Assert.isTrue(cart.getCartDeliveryGroups().size() == 1);
+        Assert.isTrue(cart.getCartItems().size() == 2);
+        Assert.isTrue(cart.getCartItems().get(1).getQuantity() == 5.0);
+    }
+
+    /**
+     * @description Set the necessary delivery address fields within the Cart Delivery Group.
+     * @param cartDeliveryGroup The Cart Delivery Group to update 
+     */
+    private static void setAddressFields(CartExtension.CartDeliveryGroup cartDeliveryGroup) {
+        cartDeliveryGroup.setDeliverToCity('Foxboro');
+        cartDeliveryGroup.setDeliverToCountry('USA');
+        cartDeliveryGroup.setDeliverToFirstName('Tom');
+        cartDeliveryGroup.setDeliverToLastName('Brady');
+        cartDeliveryGroup.setDeliverToName('Bill Belichick');
+        cartDeliveryGroup.setDeliverToPostalCode('02035');
+        cartDeliveryGroup.setDeliverToState('MA');
+        cartDeliveryGroup.setDeliverToStreet('2 Patriot Place');
+        cartDeliveryGroup.setCompanyName('New England Patriots');
+    }
+
+    /**
+     * @description Create a new ContactPointAddress record in the DB
+     * @param cart Representation of a `WebCart` record
+     * @param contactPointAddress Contact Point Address record to insert
+     */
+    private static void insertContactPointAddress(CartExtension.Cart cart, ContactPointAddress contactPointAddress) {
+        contactPointAddress.ParentId = cart.getAccountId();
+        contactPointAddress.Name = 'ContactPointAddress';
+        contactPointAddress.Street = '2 Patriot Place';
+        contactPointAddress.City = 'Foxboro';
+        contactPointAddress.Country = 'USA';
+        contactPointAddress.PostalCode = '02035';
+        contactPointAddress.State = 'MA';
+
+        insert contactPointAddress;
+    }
+
+    /**
+     * @description Mock version of Split Shipment Service.
+     */
+    global class MockDefaultSplitShipmentService extends CartExtension.SplitShipmentServiceMock {
+
+        global override void arrangeItems(CartExtension.ItemArrangementRequest request) {
+            CartExtension.Cart cart = request.getCart();
+            cart.setName(cart.getName() + ', ' + 'Default Split Shipment Service was invoked');
+        }
+    }
+}


### PR DESCRIPTION
**Overview**

Adding some sample Split Shipment Service Apex classes, one that calls `super` and one that has some custom logic to split the shipment based on product conveyability. Non-conveyable items may take longer to pick, pack, and ship at a warehouse, which means they could end up on a different truck (with a different delivery date estimate). Merchants may want to create a separate delivery group for non-conveyable items. Also included a unit test class which verifies both samples.

NOTE: In order to run the tests, you must configure the `IsConveyable__c` custom checkbox field in your org for the `Product2` and `CartDeliveryGroup` entities.

**Testing Details**

- Verified the Apex utests pass in a `248` org
- 97% code coverage of `SplitShipmentSample.apex`
- 100% code coverage of `SplitShipmentCallsSuper.apex`
- Ran the sample Apex in a Steam Org + Store and verified that non-conveyable items were placed in a non-conveyable Cart Delivery Group (see screenshot below).

**Testing Screenshots**

_Unit Tests_

![Screenshot 2023-12-13 at 12 14 14 PM](https://github.com/forcedotcom/commerce-extensibility/assets/100236257/2324f817-9751-47b0-b83e-eefe389c1409)

_Manual Test_

![Screenshot 2023-12-13 at 12 17 03 PM](https://github.com/forcedotcom/commerce-extensibility/assets/100236257/9ad030a8-3c01-46f7-8d58-e1d3f0d44b11)
