### PR TITLE
CreateOrder Extension point example with unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a reference implementation of the Commerce Extensibilit
 - Shipping Calculator
 - Tax Calculator
 - Tax Service
+- Create Order
 
 Each set of sample code includes: an Apex class, a test class, and any necessary resource files.
 
@@ -34,6 +35,12 @@ The sample code for Tax Calculator includes an Apex class (in `TaxCalculatorSamp
 The sample code for Tax Service includes the following Apex classes :
 - an Apex class (in `TaxServiceSample.apxc`) that calls an external service to retrieve tax calculation data and then saves that in the `CalculateTaxesResponseLineItem` list.
 - an Apex class (in `TaxServiceExtensionResolverSample.apxc`) which selects different resolution states (EXECUTE_DEFAULT, EXECUTE_REGISTERED and OFF) for different locales to execute respective implementations (Extension Providers or the Default Salesforce Internal Tax Api).
+
+## Create Order 
+
+The sample code for Create Order extension point includes an Apex class (in `CreateOrderSample.apxc`) that provides an example of how to work with the [OrderGraph](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/OrderGraph.html).
+There is a unit test (see `CreateOrderSampleUnitTest.apxc`) that follows the approach with [Mocking the Base Apex Class in Tests](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/mock-the-base-apex-class.html).
+Also, there is an "integration" test (see `CreateOrderSampleIntegrationTest.apxc`) that 
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 This repository contains a reference implementation of the Commerce Extensibility Framework. It includes sample code for extending the following services:
 
-- Pricing
-- Shipping Calculator
-- Tax Calculator
-- Tax Service
-- Create Order
+- [Domain Extensions for Cart Calculate API](#domain-extensions-for-cart-calculate-api):
+	- Pricing
+	- Shipping Calculator
+	- Tax Calculator
+	- Tax Service
+- [Domain Extension for Checkout](#domain-extension-for-checkout)
+	- Checkout Create Order
 
 Each set of sample code includes: an Apex class, a test class, and any necessary resource files.
 
@@ -14,35 +16,31 @@ Live Heroku services are used to simulate a connection to a third-party system. 
 
 **Warning**: The sample code and Heroku services are provided "as is" for demonstration purposes only. Do not use the source code in a production system without modifying and testing it first. And do not use the Heroku services in a production system under any circumstances.
 
-## Pricing Service
+## Domain Extensions for Cart Calculate API
+
+### Pricing Service
 
 The sample code for Pricing Service includes an Apex class (in `PricingServiceSample.apxc`) that calls an external service to retrieve product prices and then saves that price in the `PricingResponseItems` list.
 
-## Pricing Calculator
+### Pricing Calculator
 
 The sample code for Pricing Calculator includes an Apex class (in `PricingCalculatorSample.apxc`) that calls an external service to retrieve pricing information and then save those taxes in `CartItem`.
 
-## Shipping Calculator
+### Shipping Calculator
 
 The sample code for Shipping Calculator includes an Apex class (in `ShippingCalculatorSample.apxc`) that calls an external service to retrieve shipping rates and then save that rate as an additional charge in the `CartItems` list.
 
-## Tax Calculator
+### Tax Calculator
 
 The sample code for Tax Calculator includes an Apex class (in `TaxCalculatorSample.apxc`) that calls an external service to retrieve tax information and then save those taxes in `CartTaxes` in `CartItems` and `CartItemAdjustments`.
 
-## Tax Service
+### Tax Service
 
 The sample code for Tax Service includes the following Apex classes :
 - an Apex class (in `TaxServiceSample.apxc`) that calls an external service to retrieve tax calculation data and then saves that in the `CalculateTaxesResponseLineItem` list.
 - an Apex class (in `TaxServiceExtensionResolverSample.apxc`) which selects different resolution states (EXECUTE_DEFAULT, EXECUTE_REGISTERED and OFF) for different locales to execute respective implementations (Extension Providers or the Default Salesforce Internal Tax Api).
 
-## Create Order 
-
-The sample code for Create Order extension point includes an Apex class (in `CreateOrderSample.apxc`) that provides an example of how to work with the [OrderGraph](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/OrderGraph.html).
-There is a unit test (see `CreateOrderSampleUnitTest.apxc`) that follows the approach with [Mocking the Base Apex Class in Tests](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/mock-the-base-apex-class.html).
-Also, there is an "integration" test (see `CreateOrderSampleIntegrationTest.apxc`) that 
-
-## Error Handling
+### Error Handling
 
 There are two types of errors that can surface from the reference implementations: user errors (which the shopper can see and correct) and admin errors (which the shopper can’t fix).
 
@@ -51,6 +49,16 @@ All reference implementations include examples of how to propagate an error to t
 To propagate an error to the admin, throw an exception from the reference implementation. The user is presented with a generic error message telling them to contact their admin. At the same time, a Platform Status Alert Event platform event is published. A notification is created for the admin to see the error message.
 
 To learn how to create a Platform Status Alert Event trigger for the notification, see [PlatformStatusAlertEvent](https://developer.salesforce.com/docs/atlas.en-us.platform_events.meta/platform_events/sforce_api_objects_platformstatusalertevent.htm) and [Flow Core Action: Send Custom Notification](https://help.salesforce.com/s/articleView?id=sf.flow_ref_elements_actions_sendcustomnotification.htm&type=5).
+
+## Domain Extension for Checkout
+### Checkout Create Order
+
+The sample code for [Checkout Create Order](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/CheckoutCreateOrder.html) extension point includes an Apex class (see [CreateOrderSample.cls](commerce/domain/checkout/order/createOrder/classes/CreateOrderSample.cls) that provides an example of how to work with the [OrderGraph](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/OrderGraph.html).
+
+A unit test (see [CreateOrderSampleUnitTest.cls](commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls))) that follows this approach for [Mocking the Base Apex Class in Tests](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/mock-the-base-apex-class.html).
+
+Also, there is an "integration" test (see [CreateOrderSampleIntegrationTest.cls](commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls)) that verifies implementation of the CreateOrder extension that calls real default extension point behavior. This testing approach can be used in addition to unit test, it has wider test coverage, but it is less isolated than unit test presented in the example below.
+
 
 ## Deployment
 

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSample.cls
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSample.cls
@@ -1,0 +1,28 @@
+/**
+* @description This is a sample implementation of Create Order extension.
+* This class must extend CartExtension.CheckoutCreateOrder and must be linked to the Create Order extension point (Commerce_Domain_Checkout_CreateOrder).
+*/
+public virtual class CreateOrderSample extends CartExtension.CheckoutCreateOrder{
+
+    public virtual override CartExtension.CreateOrderResponse createOrder(CartExtension.CreateOrderRequest request) {
+        CartExtension.Cart cart = request.getCart();
+        CartExtension.CreateOrderResponse response = callDefault(request);        
+        CartExtension.OrderGraph orderGraph = response.getOrderGraph();
+        Order order = orderGraph.getOrder();
+        order.Description = 'Total rounded up cost of products: ';
+        List<OrderItem> orderItems = orderGraph.getOrderItems();        
+        Decimal roundedPrice = 0.0;
+        for (OrderItem orderItem : orderItems) {
+            roundedPrice += orderItem.UnitPrice.round(System.RoundingMode.CEILING);
+        }
+        order.Description += roundedPrice;
+        return response;
+    }
+    
+    @TestVisible
+    private virtual CartExtension.CreateOrderResponse callDefault(CartExtension.CreateOrderRequest request) {
+        return super.createOrder(request);        
+    }
+
+
+}

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSample.cls-meta.xml
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls
@@ -1,0 +1,68 @@
+/*
+ * @description Example of "integration" test for CreateOrder extension point. This test is calling real default implementation of CreateOrder Extension.
+ * Please be aware that this test might fail in some orgs in case when default implementation suppose to call other services that are not properly set up / stubbed for the test.
+ */
+@isTest
+public class CreateOrderSampleIntegrationTest {
+    @isTest
+    public static void shouldRoundUpCostOfProduct() {
+        CartExtension.Cart cart = arrangeCart(new Decimal[]{1.5});
+        CreateOrderSample createOrder = new CreateOrderSample();
+        // Act
+        Test.startTest();
+        CartExtension.CreateOrderResponse response = createOrder.createOrder(new CartExtension.CreateOrderRequest(cart, '123'));
+        Test.stopTest();
+        // Assert
+        Order order = response.getOrderGraph().getOrder();
+        Assert.areEqual('Total rounded up cost of products: 2.0', order.Description);
+    }
+
+    @isTest
+    public static void shouldRoundUpCostOfSeveralProducts() {
+        CartExtension.Cart cart = arrangeCart(new Decimal[]{1.5, 2.6});
+        CreateOrderSample createOrder = new CreateOrderSample();
+        // Act
+        Test.startTest();
+        CartExtension.CreateOrderResponse response = createOrder.createOrder(new CartExtension.CreateOrderRequest(cart, '123'));
+        Test.stopTest();
+        // Assert
+        Order order = response.getOrderGraph().getOrder();
+        Assert.areEqual('Total rounded up cost of products: ' + (2.0 + 3.0), order.Description);
+    }
+
+        private static CartExtension.Cart arrangeCart(Decimal[] itemsSalePrice) {
+        Account testAccount = new Account(Name='My Account');
+        insert testAccount;
+
+        WebStore testWebStore = new WebStore(Name='My WebStore');
+        insert testWebStore;
+
+        WebCart testCart = new WebCart(Name='My Cart', WebStoreId=testWebStore.Id, AccountId=testAccount.Id);
+        insert testCart;
+
+        CartDeliveryGroup testDeliveryGroup = new CartDeliveryGroup(Name='My Delivery Group', CartId=testCart.Id);
+        insert testDeliveryGroup;
+
+        Product2 testShippingChargeProduct = new Product2(Name = 'Test Shipping Charge', IsActive = true);
+        insert testShippingChargeProduct;
+
+        CartDeliveryGroupMethod testCartDeliveryGroupMethod = new CartDeliveryGroupMethod(Carrier = 'My Carrier', ClassOfService = 'My Class of Service',
+                CartDeliveryGroupId = testDeliveryGroup.Id, WebCartId=testCart.Id, ProductId = testShippingChargeProduct.Id,
+                Name = 'Test Name', ShippingFee = 1.2);
+        insert testCartDeliveryGroupMethod;
+
+        testDeliveryGroup.SelectedDeliveryMethodId = testCartDeliveryGroupMethod.Id;
+        update testDeliveryGroup;
+
+        for (Decimal salesPrice : itemsSalePrice) {
+            CartItem testCartItem = new CartItem(Name='My Cart Item', SalesPrice = salesPrice, CartId=testCart.Id, CartDeliveryGroupId=testDeliveryGroup.Id);
+            insert testCartItem;
+        }
+
+        WebCartAdjustmentBasis testCartAdjustmentBasis = new WebCartAdjustmentBasis(Name='My Coupon', WebCartId=testCart.Id);
+        insert testCartAdjustmentBasis;
+
+        return CartExtension.CartTestUtil.getCart(testCart.Id);
+    }
+
+}

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls
@@ -30,7 +30,7 @@ public class CreateOrderSampleIntegrationTest {
         Assert.areEqual('Total rounded up cost of products: ' + (2.0 + 3.0), order.Description);
     }
 
-        private static CartExtension.Cart arrangeCart(Decimal[] itemsSalePrice) {
+    private static CartExtension.Cart arrangeCart(Decimal[] itemsSalePrice) {
         Account testAccount = new Account(Name='My Account');
         insert testAccount;
 

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls-meta.xml
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleIntegrationTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls
@@ -45,8 +45,6 @@ public class CreateOrderSampleUnitTest {
             order.AccountId = cart.getAccountId();
             order.OwnerId = cart.getOwnerId();
             order.SalesStoreId = cart.getWebStoreId();
-            // cart does not support PoNumber yet
-            //order.PoNumber = cart.getPoNumber();
             Address billingAddress = cart.getBillingAddress();
             if (billingAddress != null) {
                 order.BillingStreet = billingAddress.Street;

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls
@@ -1,0 +1,147 @@
+/*
+ * @description Example of unit test for CreateOrder extension point. This test is mocking out default implementation of CreateOrder Extension so
+ * the test is isolated from the dependencies on other services that default implementation might have.
+ */
+@isTest
+public class CreateOrderSampleUnitTest {
+    
+    @isTest
+    public static void shouldRoundUpCostOfProduct() {
+        CartExtension.Cart cart = arrangeCart(new Decimal[]{1.5});
+        CreateOrderSample createOrder = new CreateOrderSampleMock();
+        // Act
+        Test.startTest();
+        CartExtension.CreateOrderResponse response = createOrder.createOrder(new CartExtension.CreateOrderRequest(cart, '123'));
+        Test.stopTest();
+        // Assert
+        Order order = response.getOrderGraph().getOrder();
+        Assert.areEqual('Total rounded up cost of products: 2.0', order.Description);
+    }
+
+    @isTest
+    public static void shouldRoundUpCostOfSeveralProducts() {
+        CartExtension.Cart cart = arrangeCart(new Decimal[]{1.5, 2.6});
+        CreateOrderSample createOrder = new CreateOrderSampleMock();
+        // Act
+        Test.startTest();
+        CartExtension.CreateOrderResponse response = createOrder.createOrder(new CartExtension.CreateOrderRequest(cart, '123'));
+        Test.stopTest();
+        // Assert
+        Order order = response.getOrderGraph().getOrder();
+        Assert.areEqual('Total rounded up cost of products: ' + (2.0 + 3.0), order.Description);
+    }
+    
+    /*
+     * Mock of CreateOrderSample class. It provides simplified implementation of cart to order mapping. 
+     */    
+    public class CreateOrderSampleMock extends CreateOrderSample {
+        
+        public override CartExtension.CreateOrderResponse callDefault(CartExtension.CreateOrderRequest request) {
+            CartExtension.Cart cart = request.getCart();
+            CartExtension.OrderGraph orderGraph = new CartExtension.OrderGraph();
+            Order order = orderGraph.getOrder();
+            System.assert(order.Id != null);
+    
+            order.AccountId = cart.getAccountId();
+            order.OwnerId = cart.getOwnerId();
+            order.SalesStoreId = cart.getWebStoreId();
+            // cart does not support PoNumber yet
+            //order.PoNumber = cart.getPoNumber();
+            Address billingAddress = cart.getBillingAddress();
+            if (billingAddress != null) {
+                order.BillingStreet = billingAddress.Street;
+                order.BillingCity = billingAddress.City;
+                order.BillingState = billingAddress.State;
+                order.BillingPostalCode = billingAddress.PostalCode;
+                order.BillingCountry = billingAddress.Country;
+                order.BillingLatitude = billingAddress.Latitude;
+                order.BillingLongitude = billingAddress.Longitude;
+                order.BillingEmailAddress = cart.getGuestEmailAddress();
+                order.BillingPhoneNumber = cart.getGuestPhoneNumber();
+                order.TaxLocaleType = cart.getTaxType().name();
+                order.EffectiveDate = Date.today();
+                order.Status = 'Activated';
+                order.Description = 'testEPN';                
+            }
+    
+            CartExtension.CartDeliveryGroupList cdgList = cart.getCartDeliveryGroups();
+            for (Integer i = 0; i < cdgList.size(); i++) {
+                CartExtension.CartDeliveryGroup cdg = cdgList.get(i);
+                // create orderDeliveryGroup
+                OrderDeliveryGroup odg = new OrderDeliveryGroup();
+                odg.DeliverToName = cdg.getDeliverToName();
+                odg.OrderDeliveryMethodId = cdg.getDeliveryMethodId();
+                orderGraph.addNode(odg);
+    
+                // create orderItems
+                CartExtension.CartItemList cartItemList = cart.getCartItems();
+                for (Integer j = 0; j < cartItemList.size(); j++) {
+                    CartExtension.CartItem cartItem = cartItemList.get(j);
+                    OrderItem orderItem = new OrderItem();
+                    orderItem.Product2Id = cartItem.getProduct2Id();
+                    if (CartExtension.SalesItemTypeEnum.PRODUCT.equals(cartItem.getType())) {
+                        orderItem.Type = 'Order Product';
+                    } else {
+                        orderItem.Type = 'Delivery charge';
+                    }
+                    orderItem.Quantity = cartItem.getQuantity();
+                    orderItem.OrderDeliveryGroupId = odg.Id;
+                    orderItem.ListPrice = cartItem.getListPrice();
+                    orderItem.UnitPrice = cartItem.getNetUnitPrice();
+                    if (orderItem.UnitPrice == null) {
+                        orderItem.UnitPrice = cartItem.getSalesPrice() == null ? cartItem.getListPrice() : cartItem.getSalesPrice();
+                    }
+                    if (orderItem.ListPrice == null) {
+                        orderItem.ListPrice = cartItem.getSalesPrice();
+                    }
+    
+                    orderItem.GrossUnitPrice = cartItem.getNetUnitPrice();
+                    orderItem.TotalLineAmount = cartItem.getTotalLineNetAmount();
+                    orderItem.Description = cartItem.getName();
+                    orderGraph.addNode(orderItem);
+    
+                }
+            }
+    
+            CartExtension.CreateOrderResponse response = new CartExtension.CreateOrderResponse(orderGraph);
+            return response;
+        }
+
+    }
+    
+    private static CartExtension.Cart arrangeCart(Decimal[] itemsSalePrice) {
+        Account testAccount = new Account(Name='My Account');
+        insert testAccount;
+
+        WebStore testWebStore = new WebStore(Name='My WebStore');
+        insert testWebStore;
+
+        WebCart testCart = new WebCart(Name='My Cart', WebStoreId=testWebStore.Id, AccountId=testAccount.Id);
+        insert testCart;
+
+        CartDeliveryGroup testDeliveryGroup = new CartDeliveryGroup(Name='My Delivery Group', CartId=testCart.Id);
+        insert testDeliveryGroup;
+
+        Product2 testShippingChargeProduct = new Product2(Name = 'Test Shipping Charge', IsActive = true);
+        insert testShippingChargeProduct;
+
+        CartDeliveryGroupMethod testCartDeliveryGroupMethod = new CartDeliveryGroupMethod(Carrier = 'My Carrier', ClassOfService = 'My Class of Service',
+                CartDeliveryGroupId = testDeliveryGroup.Id, WebCartId=testCart.Id, ProductId = testShippingChargeProduct.Id,
+                Name = 'Test Name', ShippingFee = 1.2);
+        insert testCartDeliveryGroupMethod;
+
+        testDeliveryGroup.SelectedDeliveryMethodId = testCartDeliveryGroupMethod.Id;
+        update testDeliveryGroup;
+
+        for (Decimal salesPrice : itemsSalePrice) {
+            CartItem testCartItem = new CartItem(Name='My Cart Item', SalesPrice = salesPrice, CartId=testCart.Id, CartDeliveryGroupId=testDeliveryGroup.Id);
+            insert testCartItem;
+        }
+
+        WebCartAdjustmentBasis testCartAdjustmentBasis = new WebCartAdjustmentBasis(Name='My Coupon', WebCartId=testCart.Id);
+        insert testCartAdjustmentBasis;
+
+        return CartExtension.CartTestUtil.getCart(testCart.Id);
+    }
+
+}

--- a/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls-meta.xml
+++ b/commerce/domain/checkout/order/createOrder/classes/CreateOrderSampleUnitTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/domain/checkout/order/createOrder/package.xml
+++ b/commerce/domain/checkout/order/createOrder/package.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>CreateOrderSample</members>
+        <members>CreateOrderSampleIntegrationTest</members>
+        <members>CreateOrderSampleUnitTest</members>
+        <name>ApexClass</name>
+    </types>
+    <version>59.0</version>
+</Package>


### PR DESCRIPTION
An example for new [Checkout Create Order extension point](https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/CheckoutCreateOrder.html) with unit tests.