### PR TITLE
@W-15061789: Optimize PromotionCalculatorSample example

### DIFF
--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
@@ -12,20 +12,42 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
     public static final String DUMMY_PROMOTION_ID = '0c8xx00000004JlAAI';
     private static final String QUALIFIER_PRODUCT_ID = '01txx0000006lmmAAA';
     private static final String TARGET_PRODUCT_ID = '01txx0000006lmuAAA';
-    private static final Decimal PROMOTION_ADJUSTMENT = -2;
-    private static final Decimal QUALIFIER_QUANTITY = 5;
+    private static final Integer PROMOTION_ADJUSTMENT = -2;
+    private static final Integer QUALIFIER_QUANTITY = 5;
 
     public virtual override void calculate(CartExtension.CartCalculateCalculatorRequest request) {
-        cartextension.Cart cart = request.getCart();
-        resetAllAdjustments(cart);
-        evaluatePromotionForCartItems(cart);
+        validateBuyerActionDetailsAndEvaluatePromotion(request.getCart(), request.getOptionalBuyerActionDetails());
+    }
+
+	/**
+	 * @description Evaluate promotion for the cart items if qualifier and/or target products part of changed elements in cart.
+	 * @param cart Holds details about cart
+	 * @param optionalBuyerActionDetails The latest set of changes applied to the Cart by the Buyer
+	 */
+    private void validateBuyerActionDetailsAndEvaluatePromotion(cartextension.Cart cart, cartextension.OptionalBuyerActionDetails optionalBuyerActionDetails) {
+        if (optionalBuyerActionDetails.isPresent() || !optionalBuyerActionDetails.get().isCheckoutStarted()) {
+            List<CartExtension.CartItemChange> cartItemChanges = optionalBuyerActionDetails.get().getCartItemChanges();
+
+            for (CartExtension.CartItemChange cartItemChange : cartItemChanges) {
+                 CartExtension.OptionalCartItem optionalCartItem = cartItemChange.getChangedItem();
+                 if (optionalCartItem.isPresent()) {
+                     CartExtension.CartItem cartItem = optionalCartItem.get();
+                     if (cartItem.getProduct2Id() == ID.valueOf(QUALIFIER_PRODUCT_ID) ||
+                         cartItem.getProduct2Id() == ID.valueOf(TARGET_PRODUCT_ID)) {
+                     		resetAllAdjustments(cart);
+                        	evaluatePromotionForCartItems(cart);
+                        	break;
+                     }
+                 }
+            }
+        }
     }
 
     /**
      * @description Remove cart & cart-item level adjustments, cart validation outputs.
      * @param cart Holds details about cart
      */
-    public static void resetAllAdjustments(cartextension.Cart cart) {
+    private static void resetAllAdjustments(cartextension.Cart cart) {
 
         // Remove all cart-level adjustments
         Iterator<CartExtension.CartAdjustmentGroup> cagIter = cart.getCartAdjustmentGroups().iterator();
@@ -52,7 +74,7 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
                 ciaToRemove.add(ciaIter.next());
             }
             for(CartExtension.CartItemPriceAdjustment cia : ciaToRemove) {
-                ci.getCartItemPriceAdjustments().remove(cia);
+                 ci.getCartItemPriceAdjustments().remove(cia);
             }
         }
 
@@ -68,6 +90,8 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
             }
         }
     }
+
+
 
     /**
      * @description Evaluate BOGO promotion (Buy 5 items of qualifying product, get $2 off a unit of target product,
@@ -137,7 +161,7 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
                 // Populate TotalPromoAdjustmentAmount for cart-item & update totals based on promotion adjustment
                 ci.setTotalPromoAdjustmentAmount(totalPromotionAdjustment);
                 ci.setTotalAdjustmentAmount(totalPromotionAdjustment);
-                ci.setTotalPriceAfterAllAdjustments(totalLineAmount - totalPromotionAdjustment);
+                ci.setTotalPriceAfterAllAdjustments(totalLineAmount + totalPromotionAdjustment);
             } else {
             	continue;
             }

--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
@@ -20,26 +20,30 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
     }
 
 	/**
-	 * @description Evaluate promotion for the cart items if qualifier and/or target products part of changed elements in cart.
-	 * @param cart Holds details about cart
-	 * @param optionalBuyerActionDetails The latest set of changes applied to the Cart by the Buyer
+	 * @description Evaluate promotion for cart when OptionalBuyerActionDetails not present or
+	 * OptionalBuyerActionDetails includes qualifying/target product.
+	 * @param cart In memory representation of the Cart
+     * @param optionalBuyerActionDetails The latest set of changes applied to the Cart by the Buyer
 	 */
     private void validateBuyerActionDetailsAndEvaluatePromotion(cartextension.Cart cart, cartextension.OptionalBuyerActionDetails optionalBuyerActionDetails) {
-        if (optionalBuyerActionDetails.isPresent() || !optionalBuyerActionDetails.get().isCheckoutStarted()) {
-            List<CartExtension.CartItemChange> cartItemChanges = optionalBuyerActionDetails.get().getCartItemChanges();
+        if (!optionalBuyerActionDetails.isPresent() || optionalBuyerActionDetails.get().isCheckoutStarted()) {
+            resetAllAdjustments(cart);
+            evaluatePromotionForCartItems(cart);
+            return;
+        }
 
-            for (CartExtension.CartItemChange cartItemChange : cartItemChanges) {
-                 CartExtension.OptionalCartItem optionalCartItem = cartItemChange.getChangedItem();
-                 if (optionalCartItem.isPresent()) {
-                     CartExtension.CartItem cartItem = optionalCartItem.get();
-                     if (cartItem.getProduct2Id() == ID.valueOf(QUALIFIER_PRODUCT_ID) ||
-                         cartItem.getProduct2Id() == ID.valueOf(TARGET_PRODUCT_ID)) {
-                     		resetAllAdjustments(cart);
-                        	evaluatePromotionForCartItems(cart);
-                        	break;
-                     }
-                 }
-            }
+        List<CartExtension.CartItemChange> cartItemChanges = optionalBuyerActionDetails.get().getCartItemChanges();
+        for (CartExtension.CartItemChange cartItemChange : cartItemChanges) {
+             CartExtension.OptionalCartItem optionalCartItem = cartItemChange.getChangedItem();
+               	if (optionalCartItem.isPresent()) {
+                    CartExtension.CartItem cartItem = optionalCartItem.get();
+                       	if (cartItem.getProduct2Id() == ID.valueOf(QUALIFIER_PRODUCT_ID) ||
+                          	cartItem.getProduct2Id() == ID.valueOf(TARGET_PRODUCT_ID)) {
+                        		resetAllAdjustments(cart);
+                              	evaluatePromotionForCartItems(cart);
+                               	break;
+                       	}
+                }
         }
     }
 

--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
@@ -12,6 +12,8 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
     public static final String DUMMY_PROMOTION_ID = '0c8xx00000004JlAAI';
     private static final String QUALIFIER_PRODUCT_ID = '01txx0000006lmmAAA';
     private static final String TARGET_PRODUCT_ID = '01txx0000006lmuAAA';
+    private static final Decimal PROMOTION_ADJUSTMENT = -2;
+    private static final Decimal QUALIFIER_QUANTITY = 5;
 
     public virtual override void calculate(CartExtension.CartCalculateCalculatorRequest request) {
         cartextension.Cart cart = request.getCart();
@@ -37,11 +39,11 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
         }
 
         // Remove all cart-item level adjustments
-        Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
-        while(ciIter.hasNext()) {
+        Iterator<CartExtension.CartItem> cartItemIterator = cart.getCartItems().iterator();
+        while(cartItemIterator.hasNext()) {
 
             // For every cart item, cursor through adjustments
-            CartExtension.CartItem ci = ciIter.next();
+            CartExtension.CartItem ci = cartItemIterator.next();
             Iterator<CartExtension.CartItemPriceAdjustment> ciaIter = ci.getCartItemPriceAdjustments().iterator();
             List<CartExtension.CartItemPriceAdjustment> ciaToRemove= new List<CartExtension.CartItemPriceAdjustment>();
 
@@ -76,12 +78,13 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
 		Integer targetCount = 0;
         Integer qualifierCount = 0;
     	Integer adjustmentCount = 0;
-        Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
+        Iterator<CartExtension.CartItem> cartItemIterator = cart.getCartItems().iterator();
 
-    	if(ciIter.hasNext()) {
+		// If cartItems size is greater than 0, get qualifier, target count & apply adjustments
+    	if(cartItemIterator.hasNext()) {
     		qualifierCount = getProductCount(cart, QUALIFIER_PRODUCT_ID);
     		targetCount = getProductCount(cart, TARGET_PRODUCT_ID);
-    		adjustmentCount = qualifierCount / 5;
+    		adjustmentCount = qualifierCount / QUALIFIER_QUANTITY;
     		adjustmentCount = Math.min(adjustmentCount, targetCount);
     		applyAdjustments(cart, adjustmentCount);
     	}
@@ -93,9 +96,9 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
      * @param productId Product Id
      */
     private static Integer getProductCount(CartExtension.Cart cart, String productId) {
-		Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
-        while(ciIter.hasNext()) {
-            CartExtension.CartItem ci = ciIter.next();
+		Iterator<CartExtension.CartItem> cartItemIterator = cart.getCartItems().iterator();
+        while(cartItemIterator.hasNext()) {
+            CartExtension.CartItem ci = cartItemIterator.next();
         	if (ci.getProduct2Id() == ID.valueOf(productId)) {
     			return ci.getQuantity().intValue();
 			}
@@ -110,19 +113,18 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
      */
     private static void applyAdjustments(CartExtension.Cart cart, Integer adjustmentCount) {
 
-        Decimal promotionAdjustment = -2;
-        Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
-        while(ciIter.hasNext() && adjustmentCount > 0) {
+        Iterator<CartExtension.CartItem> cartItemIterator = cart.getCartItems().iterator();
+        while(cartItemIterator.hasNext() && adjustmentCount > 0) {
 
-            CartExtension.CartItem ci = ciIter.next();
+            CartExtension.CartItem ci = cartItemIterator.next();
             if(ci.getProduct2Id().equals(TARGET_PRODUCT_ID)) {
-                Decimal totalPromotionAdjustment = adjustmentCount * promotionAdjustment;
+                Decimal totalPromotionAdjustment = adjustmentCount * PROMOTION_ADJUSTMENT;
                 CartExtension.CartItemPriceAdjustment cia = new
                                CartExtension.CartItemPriceAdjustment(cartextension.CartAdjustmentTargetTypeEnum.ITEM, // AdjustmentTargetType
                                                                      totalPromotionAdjustment, // TotalAmount
                                                                      cartextension.PriceAdjustmentSourceEnum.PROMOTION, // AdjustmentSource
                                                                      cartextension.AdjustmentTypeEnum.ADJUSTMENT_AMOUNT, // AdjustmentType
-                                                                     promotionAdjustment, // AdjustmentValue
+                                                                     PROMOTION_ADJUSTMENT, // AdjustmentValue
                                                                      DUMMY_PROMOTION_ID); // PriceAdjustmentCauseId
                 Decimal totalLineAmount = (ci.getTotalLineAmount() == null) ?
                                             (ci.getSalesPrice() * ci.getQuantity()) : ci.getTotalLineAmount();

--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSample.cls
@@ -1,17 +1,22 @@
- /**
+/**
   * @description This sample is for the situations where Promotion Calculation needs to be extended or overridden via the
   * extension point for the Promotion Calculator. You are expected to refer this and write your own implementation.
   * This class must extend the CartExtension.PromotionsCartCalculator class to be processed.
+  *
+  * In this example cart items are evaluated against a BOGO (Buy X, Get Y) promotion > Buy 5 items of qualifying product X,
+  * get $2 off a unit of target Y.
   */
 public with sharing class PromotionCalculatorSample extends CartExtension.PromotionsCartCalculator {
 
-    // You MUST change this to be a valid promotion id.
-    public static final String DUMMY_PROMOTION_ID = '0c8xx000000003FAAQ';
+    // You MUST change following to be a valid promotion, product ids.
+    public static final String DUMMY_PROMOTION_ID = '0c8xx00000004JlAAI';
+    private static final String QUALIFIER_PRODUCT_ID = '01txx0000006lmmAAA';
+    private static final String TARGET_PRODUCT_ID = '01txx0000006lmuAAA';
 
     public virtual override void calculate(CartExtension.CartCalculateCalculatorRequest request) {
         cartextension.Cart cart = request.getCart();
         resetAllAdjustments(cart);
-        applyAdjustments(cart);
+        evaluatePromotionForCartItems(cart);
     }
 
     /**
@@ -62,39 +67,78 @@ public with sharing class PromotionCalculatorSample extends CartExtension.Promot
         }
     }
 
-
     /**
-     * @description Apply flat 5 percent discount across all cart items
+     * @description Evaluate BOGO promotion (Buy 5 items of qualifying product, get $2 off a unit of target product,
+     * for cart items and apply adjustments.
      * @param cart Holds details about cart
      */
-    public static void applyAdjustments(CartExtension.Cart cart) {
-
-        Decimal pctDiscount = -5;
+    private static void evaluatePromotionForCartItems(CartExtension.Cart cart) {
+		Integer targetCount = 0;
+        Integer qualifierCount = 0;
+    	Integer adjustmentCount = 0;
         Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
+
+    	if(ciIter.hasNext()) {
+    		qualifierCount = getProductCount(cart, QUALIFIER_PRODUCT_ID);
+    		targetCount = getProductCount(cart, TARGET_PRODUCT_ID);
+    		adjustmentCount = qualifierCount / 5;
+    		adjustmentCount = Math.min(adjustmentCount, targetCount);
+    		applyAdjustments(cart, adjustmentCount);
+    	}
+    }
+
+    /**
+     * @description Helper method to get count of given product in cart.
+     * @param cart Holds details about cart
+     * @param productId Product Id
+     */
+    private static Integer getProductCount(CartExtension.Cart cart, String productId) {
+		Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
         while(ciIter.hasNext()) {
+            CartExtension.CartItem ci = ciIter.next();
+        	if (ci.getProduct2Id() == ID.valueOf(productId)) {
+    			return ci.getQuantity().intValue();
+			}
+        }
+        return 0;
+    }
+
+    /**
+     * @description Apply $2 off discount on given number of target units
+     * @param cart Holds details about cart
+     * @param adjustmentCount Number of target units the discount applies to
+     */
+    private static void applyAdjustments(CartExtension.Cart cart, Integer adjustmentCount) {
+
+        Decimal promotionAdjustment = -2;
+        Iterator<CartExtension.CartItem> ciIter = cart.getCartItems().iterator();
+        while(ciIter.hasNext() && adjustmentCount > 0) {
 
             CartExtension.CartItem ci = ciIter.next();
-            Decimal totalLineAmount = (ci.getTotalLineAmount() == null) ?
-                                      (ci.getSalesPrice() * ci.getQuantity()) : ci.getTotalLineAmount();
-            Decimal promotionAdjustment = totalLineAmount * (pctDiscount/100);
-            promotionAdjustment = promotionAdjustment.setScale(2,System.RoundingMode.HALF_DOWN); // Currency precision rounding
-            CartExtension.CartItemPriceAdjustment cia = new
-                                CartExtension.CartItemPriceAdjustment(cartextension.CartAdjustmentTargetTypeEnum.ITEM, // AdjustmentTargetType
-                                                                      promotionAdjustment, // TotalAmount
-                                                                      cartextension.PriceAdjustmentSourceEnum.PROMOTION, // AdjustmentSource
-                                                                      cartextension.AdjustmentTypeEnum.ADJUSTMENT_PERCENTAGE, // AdjustmentType
-                                                                      pctDiscount, // AdjustmentValue
-                                                                      DUMMY_PROMOTION_ID); // PriceAdjustmentCauseId
-            cia.setPriority(1);
-            cia.setAdjustmentAmountScope(cartextension.AdjustmentAmountScopeEnum.TOTAL);
-            cia.setDescription('PromotionCalculator');
-            ci.getCartItemPriceAdjustments().add(cia);
+            if(ci.getProduct2Id().equals(TARGET_PRODUCT_ID)) {
+                Decimal totalPromotionAdjustment = adjustmentCount * promotionAdjustment;
+                CartExtension.CartItemPriceAdjustment cia = new
+                               CartExtension.CartItemPriceAdjustment(cartextension.CartAdjustmentTargetTypeEnum.ITEM, // AdjustmentTargetType
+                                                                     totalPromotionAdjustment, // TotalAmount
+                                                                     cartextension.PriceAdjustmentSourceEnum.PROMOTION, // AdjustmentSource
+                                                                     cartextension.AdjustmentTypeEnum.ADJUSTMENT_AMOUNT, // AdjustmentType
+                                                                     promotionAdjustment, // AdjustmentValue
+                                                                     DUMMY_PROMOTION_ID); // PriceAdjustmentCauseId
+                Decimal totalLineAmount = (ci.getTotalLineAmount() == null) ?
+                                            (ci.getSalesPrice() * ci.getQuantity()) : ci.getTotalLineAmount();
 
-            // Populate TotalPromoAdjustmentAmount for cart-item & update totals based on promotion adjustment
-            ci.setTotalPromoAdjustmentAmount(promotionAdjustment);
-            ci.setTotalAdjustmentAmount(promotionAdjustment);
-            ci.setTotalPriceAfterAllAdjustments(ci.getSalesPrice() - promotionAdjustment);
+                cia.setPriority(1);
+                cia.setAdjustmentAmountScope(cartextension.AdjustmentAmountScopeEnum.TOTAL);
+                cia.setDescription('PromotionCalculator');
+                ci.getCartItemPriceAdjustments().add(cia);
 
+                // Populate TotalPromoAdjustmentAmount for cart-item & update totals based on promotion adjustment
+                ci.setTotalPromoAdjustmentAmount(totalPromotionAdjustment);
+                ci.setTotalAdjustmentAmount(totalPromotionAdjustment);
+                ci.setTotalPriceAfterAllAdjustments(totalLineAmount - totalPromotionAdjustment);
+            } else {
+            	continue;
+            }
         }
     }
 }

--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSampleTest.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSampleTest.cls
@@ -30,9 +30,25 @@ global class PromotionCalculatorSampleTest {
         // Associate qualifying & target items to the Cart and load the cart
         CartExtension.Cart cart = addItemsToCart(cartId, 10, 3);
 
+        // Arrange buyer updated cart item with target
+        List<CartExtension.CartItemChange> changedCartItems = new List<CartExtension.CartItemChange>();
+        Iterator<CartExtension.CartItem> cartItemsIterator = cart.getCartItems().iterator();
+        while (cartItemsIterator.hasNext()) {
+            CartExtension.CartItem cartItem = cartItemsIterator.next();
+            if (cartItem.getProduct2Id() == ID.valueOf(TARGET_PRODUCT_ID)) {
+                changedCartItems.add(
+                new CartExtension.CartItemChange.Builder()
+                .withChangedItem(CartExtension.OptionalCartItem.of(cartItem))
+                .withAdded(true)
+                .build());
+            }
+        }
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails.Builder()
+            .withCartItemChanges(changedCartItems).build();
+
         // Act
         Test.startTest();
-        promotionCalculator.calculate(new CartExtension.CartCalculateCalculatorRequest(cart, CartExtension.OptionalBuyerActionDetails.empty()));
+        promotionCalculator.calculate(new CartExtension.CartCalculateCalculatorRequest(cart, CartExtension.OptionalBuyerActionDetails.of(buyerActionDetails)));
         Test.stopTest();
 
         // Assert
@@ -48,7 +64,7 @@ global class PromotionCalculatorSampleTest {
         // Verify CartItem adjustment and total price
 		Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getTotalPromoAdjustmentAmount());
         Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getTotalAdjustmentAmount());
-        Assert.areEqual(((TARGET_SALES_PRICE * 3) - TOTAL_ADJUSTMENT_AMOUNT), cart.getCartItems().get(1).getTotalPriceAfterAllAdjustments());
+        Assert.areEqual(((TARGET_SALES_PRICE * 3) + TOTAL_ADJUSTMENT_AMOUNT), cart.getCartItems().get(1).getTotalPriceAfterAllAdjustments());
     }
 
     /**
@@ -63,9 +79,26 @@ global class PromotionCalculatorSampleTest {
         // Associate qualifying & target items to the Cart and load the cart
         CartExtension.Cart cart = addItemsToCart(cartId, 4, 1);
 
+        // Arrange buyer updated cart item with target
+        List<CartExtension.CartItemChange> changedCartItems = new List<CartExtension.CartItemChange>();
+        Iterator<CartExtension.CartItem> cartItemsIterator = cart.getCartItems().iterator();
+        while (cartItemsIterator.hasNext()) {
+            CartExtension.CartItem cartItem = cartItemsIterator.next();
+            if (cartItem.getProduct2Id() == ID.valueOf(TARGET_PRODUCT_ID)) {
+                changedCartItems.add(
+                new CartExtension.CartItemChange.Builder()
+                .withChangedItem(CartExtension.OptionalCartItem.of(cartItem))
+                .withAdded(true)
+                .build());
+            }
+        }
+        CartExtension.BuyerActionDetails buyerActionDetails = new CartExtension.BuyerActionDetails.Builder()
+            .withCartItemChanges(changedCartItems).build();
+
+
         // Act
         Test.startTest();
-        promotionCalculator.calculate(new CartExtension.CartCalculateCalculatorRequest(cart, CartExtension.OptionalBuyerActionDetails.empty()));
+        promotionCalculator.calculate(new CartExtension.CartCalculateCalculatorRequest(cart, CartExtension.OptionalBuyerActionDetails.of(buyerActionDetails)));
         Test.stopTest();
 
         // Assert

--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSampleTest.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSampleTest.cls
@@ -71,7 +71,7 @@ global class PromotionCalculatorSampleTest {
      * @description Verify Promotion is not applied when cart does not include enough qualifying or target items.
      */
     @IsTest
-    public static void testPromotionAndPriceAdjustments_WithOutQualifierAndTargetItems() {
+    public static void testPromotionAndPriceAdjustments_WithInsufficientQualifierAndTargetItems() {
         // Arrange
         // Create a Cart with CHECKOUT status
         Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
@@ -108,6 +108,39 @@ global class PromotionCalculatorSampleTest {
         // Verify that the CartItem has 0 price adjustments.
         Assert.areEqual(0, cart.getCartItems().get(0).getCartItemPriceAdjustments().size());
         Assert.areEqual(0, cart.getCartItems().get(1).getCartItemPriceAdjustments().size());
+    }
+
+    /**
+     * @description Verify Promotion is correctly applied on cart item w/o optional buyer action details.
+     */
+    @IsTest
+    public static void testPromotionAndPriceAdjustments_WithOutBuyerActionDetails() {
+        // Arrange
+        // Create a Cart with CHECKOUT status
+        Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
+
+        // Associate qualifying & target items to the Cart and load the cart
+        CartExtension.Cart cart = addItemsToCart(cartId, 5, 2);
+
+        // Act
+        Test.startTest();
+        promotionCalculator.calculate(new CartExtension.CartCalculateCalculatorRequest(cart, CartExtension.OptionalBuyerActionDetails.empty()));
+        Test.stopTest();
+
+        // Assert
+        // Verify that we have 2 CartItems
+        Assert.areEqual(2, cart.getCartItems().size());
+
+        // Verify that the CartItem has 1 price adjustment with correct adjustment type and value
+        Assert.areEqual(1, cart.getCartItems().get(1).getCartItemPriceAdjustments().size());
+        Assert.areEqual(Cartextension.AdjustmentTypeEnum.ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getCartItemPriceAdjustments().get(0).getAdjustmentType());
+        Assert.areEqual(DISCOUNT_VALUE, cart.getCartItems().get(1).getCartItemPriceAdjustments().get(0).getAdjustmentValue());
+        Assert.areEqual(DISCOUNT_VALUE, cart.getCartItems().get(1).getCartItemPriceAdjustments().get(0).getTotalAmount());
+
+        // Verify CartItem adjustment and total price
+		Assert.areEqual(DISCOUNT_VALUE, cart.getCartItems().get(1).getTotalPromoAdjustmentAmount());
+        Assert.areEqual(DISCOUNT_VALUE, cart.getCartItems().get(1).getTotalAdjustmentAmount());
+        Assert.areEqual(((TARGET_SALES_PRICE * 2) + DISCOUNT_VALUE), cart.getCartItems().get(1).getTotalPriceAfterAllAdjustments());
     }
 
     /**

--- a/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSampleTest.cls
+++ b/commerce/domain/promotion/cart/calculator/classes/PromotionCalculatorSampleTest.cls
@@ -8,24 +8,27 @@ global class PromotionCalculatorSampleTest {
     private static final String WEBSTORE_NAME = 'My WebStore';
     private static final String DELIVERYGROUP_NAME = 'Default Delivery Group';
     private static final String CART_ITEM1_NAME = 'My Cart Item 1';
-    private static final String PRODUCT_ID = '01tSB000000I0knYAC';
-    private static final Decimal SALES_PRICE = 80.00;
-    private static final Decimal DISCOUNT_VALUE = -5.0;
+    private static final String CART_ITEM2_NAME = 'My Cart Item 2';
+    private static final String TARGET_PRODUCT_ID = '01txx0000006lmuAAA';
+    private static final String QUALIFIER_PRODUCT_ID = '01txx0000006lmmAAA';
+    private static final Decimal TARGET_SALES_PRICE = 10.00;
+    private static final Decimal QUALIFIER_SALES_PRICE = 20.00;
+    private static final Decimal DISCOUNT_VALUE = -2.0;
     private static final Decimal TOTAL_ADJUSTMENT_AMOUNT = -4.0;
 
     private static final PromotionCalculatorSample promotionCalculator = new PromotionCalculatorSample();
 
     /**
-     * @description Verify that Promotion is correctly applied on cart item.
+     * @description Verify Promotion is correctly applied on cart item.
      */
     @IsTest
-    public static void testPromotionAndPriceAdjustments() {
+    public static void testPromotionAndPriceAdjustments_WithQualifierAndTargetItems() {
         // Arrange
         // Create a Cart with CHECKOUT status
         Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
 
-        // Associate an item to the Cart and load the cart
-        CartExtension.Cart cart = addItemToCart(cartId);
+        // Associate qualifying & target items to the Cart and load the cart
+        CartExtension.Cart cart = addItemsToCart(cartId, 10, 3);
 
         // Act
         Test.startTest();
@@ -33,19 +36,45 @@ global class PromotionCalculatorSampleTest {
         Test.stopTest();
 
         // Assert
-        // Verify that we have 1 CartItem
-        Assert.areEqual(1, cart.getCartItems().size());
+        // Verify that we have 2 CartItems
+        Assert.areEqual(2, cart.getCartItems().size());
 
         // Verify that the CartItem has 1 price adjustment with correct adjustment type and value
-        Assert.areEqual(1, cart.getCartItems().get(0).getCartItemPriceAdjustments().size());
-        Assert.areEqual(Cartextension.AdjustmentTypeEnum.ADJUSTMENT_PERCENTAGE, cart.getCartItems().get(0).getCartItemPriceAdjustments().get(0).getAdjustmentType());
-        Assert.areEqual(DISCOUNT_VALUE, cart.getCartItems().get(0).getCartItemPriceAdjustments().get(0).getAdjustmentValue());
-        Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(0).getCartItemPriceAdjustments().get(0).getTotalAmount());
+        Assert.areEqual(1, cart.getCartItems().get(1).getCartItemPriceAdjustments().size());
+        Assert.areEqual(Cartextension.AdjustmentTypeEnum.ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getCartItemPriceAdjustments().get(0).getAdjustmentType());
+        Assert.areEqual(DISCOUNT_VALUE, cart.getCartItems().get(1).getCartItemPriceAdjustments().get(0).getAdjustmentValue());
+        Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getCartItemPriceAdjustments().get(0).getTotalAmount());
 
         // Verify CartItem adjustment and total price
-		Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(0).getTotalPromoAdjustmentAmount());
-        Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(0).getTotalAdjustmentAmount());
-        Assert.areEqual((SALES_PRICE - TOTAL_ADJUSTMENT_AMOUNT), cart.getCartItems().get(0).getTotalPriceAfterAllAdjustments());
+		Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getTotalPromoAdjustmentAmount());
+        Assert.areEqual(TOTAL_ADJUSTMENT_AMOUNT, cart.getCartItems().get(1).getTotalAdjustmentAmount());
+        Assert.areEqual(((TARGET_SALES_PRICE * 3) - TOTAL_ADJUSTMENT_AMOUNT), cart.getCartItems().get(1).getTotalPriceAfterAllAdjustments());
+    }
+
+    /**
+     * @description Verify Promotion is not applied when cart does not include enough qualifying or target items.
+     */
+    @IsTest
+    public static void testPromotionAndPriceAdjustments_WithOutQualifierAndTargetItems() {
+        // Arrange
+        // Create a Cart with CHECKOUT status
+        Id cartId = createCartWithSpecifiedStatus(CartExtension.CartStatusEnum.CHECKOUT);
+
+        // Associate qualifying & target items to the Cart and load the cart
+        CartExtension.Cart cart = addItemsToCart(cartId, 4, 1);
+
+        // Act
+        Test.startTest();
+        promotionCalculator.calculate(new CartExtension.CartCalculateCalculatorRequest(cart, CartExtension.OptionalBuyerActionDetails.empty()));
+        Test.stopTest();
+
+        // Assert
+        // Verify that we have 2 CartItems
+        Assert.areEqual(2, cart.getCartItems().size());
+
+        // Verify that the CartItem has 0 price adjustments.
+        Assert.areEqual(0, cart.getCartItems().get(0).getCartItemPriceAdjustments().size());
+        Assert.areEqual(0, cart.getCartItems().get(1).getCartItemPriceAdjustments().size());
     }
 
     /**
@@ -77,7 +106,7 @@ global class PromotionCalculatorSampleTest {
      *
      * @return Cart
      */
-    private static CartExtension.Cart addItemToCart(ID cartId) {
+    private static CartExtension.Cart addItemsToCart(ID cartId, Decimal qualifierCount, Decimal targetCount) {
         CartDeliveryGroup deliveryGroup = new CartDeliveryGroup(Name = DELIVERYGROUP_NAME, CartId = cartId);
         insert deliveryGroup;
 
@@ -85,11 +114,21 @@ global class PromotionCalculatorSampleTest {
             Name = CART_ITEM1_NAME,
             CartId = cartId,
             CartDeliveryGroupId = deliveryGroup.Id,
-            Quantity = 1,
-            Product2Id = PRODUCT_ID,
-            SalesPrice = SALES_PRICE,
+            Quantity = qualifierCount,
+            Product2Id = QUALIFIER_PRODUCT_ID,
+            SalesPrice = QUALIFIER_SALES_PRICE,
             Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
         insert cartItem1;
+
+        CartItem cartItem2 = new CartItem(
+                Name = CART_ITEM2_NAME,
+                CartId = cartId,
+                CartDeliveryGroupId = deliveryGroup.Id,
+                Quantity = targetCount,
+                Product2Id = TARGET_PRODUCT_ID,
+                SalesPrice = TARGET_SALES_PRICE,
+                Type = CartExtension.SalesItemTypeEnum.PRODUCT.name());
+        insert cartItem2;
 
         // Return Cart
         return CartExtension.CartTestUtil.getCart(cartId);


### PR DESCRIPTION
Updating PromotionCalculatorSample example to evaluate a BOGO promotion instead of applying flat 5% off to all cart items. Verified tests passing in Developer Console (Screenshot below also shows PromotionCalculatorSample CodeCoverage).

<img width="1848" alt="Screenshot 2024-03-26 at 9 48 06 AM" src="https://github.com/forcedotcom/commerce-extensibility/assets/157054439/c92bab83-0200-4e84-b635-d47e59a1feeb">
