### PR TITLE
@W-14119934 Pricing Extensibility Sample apex updates

### DIFF
--- a/commerce/domain/pricing/service/classes/PricingServiceSample.cls
+++ b/commerce/domain/pricing/service/classes/PricingServiceSample.cls
@@ -138,15 +138,18 @@ public class PricingServiceSample extends commercestorepricing.PricingService {
       txnResponse.getTotalProductAmount() + txnResponse.getTotalAdjustmentAmount()
     );
 
+    /**
+     * Override success/failure of a product easily by adding an error message to the product.
+     * Here is a sample code demonstrating how to set error messages for products.
+     * We are failing the first product in the response.
+     * 
     if (!txnItemCollection.isEmpty()) {
-      // Override success/failure of a product easily by adding an error message to the product.
-      // Here is a sample code demonstrating how to set error messages for products.
-      // We are failing the first product in the response.
-      
-      // String customErrorMessage = 'We no longer sell this particular product.';
-      // String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
-      // txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
+      String customErrorMessage = 'We no longer sell this particular product.';
+      String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
+      txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
     }
+	  */
+
     return txnResponse;
   }
 

--- a/commerce/domain/pricing/service/classes/PricingServiceSample.cls
+++ b/commerce/domain/pricing/service/classes/PricingServiceSample.cls
@@ -123,7 +123,6 @@ public class PricingServiceSample extends commercestorepricing.PricingService {
     commercestorepricing.TxnPricingResponseItemCollection txnItemCollection = txnResponse.getTxnPricingResponseItems();
     for (Integer j = 0; j < txnItemCollection.size(); j++) {
       commercestorepricing.TransactionalPricingResponseItem txnItem = txnItemCollection.get(j);
-      txnItem.setLineId(appendField(prefix, txnItem.getLineId()));
       txnItem.setProductId(appendField(prefix, txnItem.getProductId()));
       txnItem.setUnitPricePriceBookEntryId(
         appendField(prefix, txnItem.getUnitPricePriceBookEntryId())
@@ -140,11 +139,13 @@ public class PricingServiceSample extends commercestorepricing.PricingService {
     );
 
     if (!txnItemCollection.isEmpty()) {
-      // Override success/failure of a product easily by adding an error message to the product. Here
-      // we are failing the first product in the response.
-      String customErrorMessage = 'We no longer sell this particular product.';
-      String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
-      txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
+      // Override success/failure of a product easily by adding an error message to the product.
+      // Here is a sample code demonstrating how to set error messages for products.
+      // We are failing the first product in the response.
+      
+      // String customErrorMessage = 'We no longer sell this particular product.';
+      // String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
+      // txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
     }
     return txnResponse;
   }

--- a/commerce/domain/pricing/service/classes/PricingServiceSample.cls
+++ b/commerce/domain/pricing/service/classes/PricingServiceSample.cls
@@ -146,13 +146,12 @@ public class PricingServiceSample extends commercestorepricing.PricingService {
      * Here is a sample code demonstrating how to set error messages for products.
      * We are failing the first product in the response.
      * Warning: Uncommenting the code below will cause cart operations to fail.
-     * 
-    if (!txnItemCollection.isEmpty()) {
-      String customErrorMessage = 'We no longer sell this particular product.';
-      String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
-      txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
-    }
-    */
+     */
+    // if (!txnItemCollection.isEmpty()) {
+    //  String customErrorMessage = 'We no longer sell this particular product.';
+    //  String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
+    //  txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
+    // }
 
     return txnResponse;
   }

--- a/commerce/domain/pricing/service/classes/PricingServiceSample.cls
+++ b/commerce/domain/pricing/service/classes/PricingServiceSample.cls
@@ -100,6 +100,9 @@ public class PricingServiceSample extends commercestorepricing.PricingService {
   // amount, total adjustment amount and total amount. Item level - line id, product id, unit price,
   // list price, unit pricebook entry id, unit adjustment amount, total line amount, total adjustment
   // amount, total price, and total list price.
+  //
+  // Caution: If you're overriding fields containing Salesforce IDs, ensure that they are valid IDs. Otherwise,
+  // subsequent operations may fail unexpectedly.
   public override commercestorepricing.TransactionalPricingResponse processTransactionalPrice(
     commercestorepricing.TransactionalPricingRequest request2
   ) {
@@ -142,13 +145,14 @@ public class PricingServiceSample extends commercestorepricing.PricingService {
      * Override success/failure of a product easily by adding an error message to the product.
      * Here is a sample code demonstrating how to set error messages for products.
      * We are failing the first product in the response.
+     * Warning: Uncommenting the code below will cause cart operations to fail.
      * 
     if (!txnItemCollection.isEmpty()) {
       String customErrorMessage = 'We no longer sell this particular product.';
       String localizedErrorMessage = 'Wir verkaufen dieses spezielle Produkt nicht mehr.';
       txnItemCollection.get(0).setError(customErrorMessage, localizedErrorMessage);
     }
-	  */
+    */
 
     return txnResponse;
   }


### PR DESCRIPTION
Issues
- Prefix added to ids in processTransactionalPrice causes mismatch, so pricingLineItem is not pulled from the lineItemIdToPricingDetailsMap.
- ProcessTransactionalPrice sets an error for the first item in the response. This causes add to cart to fail when the sample apex class is registered