### PR TITLE
@W-15359680: Adding cart endpoint extension samples

### DIFF
--- a/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls
@@ -1,0 +1,5 @@
+public with sharing class CartItemCollectionExtensionSample {
+    public CartItemCollectionExtensionSample() {
+
+    }
+}

--- a/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls
@@ -1,12 +1,15 @@
 /**
- * Sample extension for updating the quantity of a cart item while adding an item to the cart.
+ * Sample extension for enforcing quantity constraints on a cart item while adding an item to the cart.
  * This corresponds to the endpoint /commerce/webstores/${webstoreId}/carts/${activeCartOrId}/cart-items
  * and is identified by the EPN Commerce_Endpoint_Cart_ItemCollection for registration/mapping.
  */
 public with sharing class CartItemCollectionExtensionSample extends ConnectApi.BaseEndpointExtension {
 
+    // Define a constant for the maximum quantity allowed
+    private static final Integer MAX_QUANTITY = 100;
+
     /**
-     * Overrides the beforePost method to update the quantity of a cart item.
+     * Overrides the beforePost method to enforce a maximum quantity of a cart item.
      *
      * @param request The endpoint extension request containing cart item data.
      * @return The modified endpoint extension request with updated quantity.
@@ -24,12 +27,23 @@ public with sharing class CartItemCollectionExtensionSample extends ConnectApi.B
         // Check if cartItemInput is not null
         if (cartItemInput != null) {
             // Retrieve the quantity from the cart item input
-            String quantity = cartItemInput.getQuantity();
+            String quantityStr = cartItemInput.getQuantity();
 
             // Check if quantity is not null
-            if (quantity != null) {
-                // Set the quantity to 5
-                cartItemInput.setQuantity('5');
+            if (quantityStr != null) {
+                try {
+                    // Convert quantity from String to Integer
+                    Integer quantity = Integer.valueOf(quantityStr);
+
+                    // Enforce the maximum quantity
+                    if (quantity > MAX_QUANTITY) {
+                        quantity = MAX_QUANTITY;
+                        // Set the enforced quantity back to the cart item input
+                        cartItemInput.setQuantity(quantity.toString());
+                    }
+                } catch (Exception e) {
+                    throw new InvalidFormatException('Invalid quantity format: ' + quantityStr);
+                }
             }
 
             /**

--- a/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls
@@ -1,5 +1,45 @@
-public with sharing class CartItemCollectionExtensionSample {
-    public CartItemCollectionExtensionSample() {
+/**
+ * Sample extension for updating the quantity of a cart item while adding an item to the cart.
+ * This corresponds to the endpoint /commerce/webstores/${webstoreId}/carts/${activeCartOrId}/cart-items
+ * and is identified by the EPN Commerce_Endpoint_Cart_ItemCollection for registration/mapping.
+ */
+public with sharing class CartItemCollectionExtensionSample extends ConnectApi.BaseEndpointExtension {
 
+    /**
+     * Overrides the beforePost method to update the quantity of a cart item.
+     *
+     * @param request The endpoint extension request containing cart item data.
+     * @return The modified endpoint extension request with updated quantity.
+     */
+    public override ConnectApi.EndpointExtensionRequest beforePost(ConnectApi.EndpointExtensionRequest request) {
+        System.debug('We are in the beforePost entry method of Commerce_Endpoint_Cart_ItemCollection extension');
+
+        /**
+         * Retrieve the cart item input from the request. This is a deep copy.
+         * The parameter name can be found in the documentation:
+         * https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/extensions.html
+         */
+        ConnectApi.CartItemInput cartItemInput = (ConnectApi.CartItemInput) request.getParam('cartItemInput');
+
+        // Check if cartItemInput is not null
+        if (cartItemInput != null) {
+            // Retrieve the quantity from the cart item input
+            String quantity = cartItemInput.getQuantity();
+
+            // Check if quantity is not null
+            if (quantity != null) {
+                // Set the quantity to 5
+                cartItemInput.setQuantity('5');
+            }
+
+            /**
+             * Update the cart item input parameter in the request.
+             * The request needs to be set in the "before" methods since what is returned is a deep copy.
+             */
+            request.setParam('cartItemInput', cartItemInput);
+        }
+
+        // Return the modified request
+        return request;
     }
 }

--- a/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls-meta.xml
+++ b/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls-meta.xml
+++ b/commerce/endpoint/cart/CartItemCollectionExtensionSample.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/commerce/endpoint/cart/CartItemExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemExtensionSample.cls
@@ -1,16 +1,32 @@
 /**
- * Sample extension for handling the edit operation on a cart item.
+ * Sample extension for updating the listPrice of a cart item based on the currencyIsoCode during edit operations.
  * This corresponds to an endpoint /commerce/webstores/${webstoreId}/carts/${activeCartOrId}/cart-items/${cartItemId}
  * and is identified by the EPN Commerce_Endpoint_Cart_Item for registration/mapping.
  */
 public with sharing class CartItemExtensionSample extends ConnectApi.BaseEndpointExtension {
 
+    // Define a constant for the USD currencyIsoCode
+    private static final String USD_CURRENCY_ISO_CODE = 'USD';
+
+    // Define a constant for the AED currencyIsoCode
+    private static final String AED_CURRENCY_ISO_CODE = 'AED';
+
+    // Define a constant for the adjustment when the currencyIsoCode is USD
+    private static final Decimal USD_ADJUSTMENT = 10;
+
+    // Define a constant for the adjustment when the currencyIsoCode is AED
+    private static final Decimal AED_ADJUSTMENT = 5;
+
+    // Define a constant for the adjustment for currencyIsoCodes other than USD and AED
+    private static final Decimal ADJUSTMENT = 2;
+
+
     /**
-     * Overrides the afterPatch method to update the currency ISO code of a cart item.
+     * Overrides the afterPatch method to update the listPrice of a cart item based on the currencyIsoCode.
      *
      * @param response The endpoint extension response containing cart item data.
      * @param request The endpoint extension request.
-     * @return The modified endpoint extension response with updated currency ISO code.
+     * @return The modified endpoint extension response with updated listPrice.
      */
     public override ConnectApi.EndpointExtensionResponse afterPatch(ConnectApi.EndpointExtensionResponse response, ConnectApi.EndpointExtensionRequest request) {
         System.debug('Entering the afterPatch method of Commerce_Endpoint_Cart_Item extension');
@@ -24,8 +40,38 @@ public with sharing class CartItemExtensionSample extends ConnectApi.BaseEndpoin
 
         // Check if cartItem is not null
         if (cartItem != null) {
-            // Set the currency ISO code to AED
-            cartItem.setCurrencyIsoCode('AED');
+            // Check if listPrice and currencyIsoCode are not null
+            if (cartItem.getListPrice() != null && cartItem.getCurrencyIsoCode() != null) {
+                
+                // Retrieve the currencyIsoCode from the cart item
+                String currencyCode = cartItem.getCurrencyIsoCode();
+
+                // Retrieve the listPrice from the cart item  
+                String listPriceStr = cartItem.getListPrice();
+
+                try {
+                    // Convert listPrice from String to Decimal
+                    Decimal listPrice = Decimal.valueOf(listPriceStr);
+
+                    // Adjust the listPrice based on the currencyIsoCode
+                    switch on currencyCode {
+                        when USD_CURRENCY_ISO_CODE {
+                            listPrice += USD_ADJUSTMENT;
+                        }
+                        when AED_CURRENCY_ISO_CODE {
+                            listPrice += AED_ADJUSTMENT;
+                        }
+                        when else {
+                            listPrice += ADJUSTMENT;
+                        }
+                    }
+
+                    // Set the adjusted listPrice back to the cart item
+                    cartItem.setListPrice(String.valueOf(listPrice));
+                } catch (Exception e) {
+                    throw new InvalidFormatException('Invalid listPrice format: ' + listPriceStr);
+                }
+            }
         }
 
         // Return the modified response

--- a/commerce/endpoint/cart/CartItemExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemExtensionSample.cls
@@ -1,5 +1,34 @@
-public with sharing class CartItemExtensionSample {
-    public CartItemExtensionSample() {
+/**
+ * Sample extension for handling the edit operation on a cart item.
+ * This corresponds to an endpoint /commerce/webstores/${webstoreId}/carts/${activeCartOrId}/cart-items/${cartItemId}
+ * and is identified by the EPN Commerce_Endpoint_Cart_Item for registration/mapping.
+ */
+public with sharing class CartItemExtensionSample extends ConnectApi.BaseEndpointExtension {
 
+    /**
+     * Overrides the afterPatch method to update the currency ISO code of a cart item.
+     *
+     * @param response The endpoint extension response containing cart item data.
+     * @param request The endpoint extension request.
+     * @return The modified endpoint extension response with updated currency ISO code.
+     */
+    public override ConnectApi.EndpointExtensionResponse afterPatch(ConnectApi.EndpointExtensionResponse response, ConnectApi.EndpointExtensionRequest request) {
+        System.debug('Entering the afterPatch method of Commerce_Endpoint_Cart_Item extension');
+
+        /**
+         * Retrieve the cart item from the response object
+         * More details on the response object can be found in the documentation:
+         * https://developer.salesforce.com/docs/commerce/salesforce-commerce/guide/extensions.html#connectapiendpointextensionresponse
+         * */
+        ConnectApi.CartItem cartItem = (ConnectApi.CartItem)response.getResponseObject();
+
+        // Check if cartItem is not null
+        if (cartItem != null) {
+            // Set the currency ISO code to AED
+            cartItem.setCurrencyIsoCode('AED');
+        }
+
+        // Return the modified response
+        return response;
     }
 }

--- a/commerce/endpoint/cart/CartItemExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemExtensionSample.cls
@@ -1,0 +1,5 @@
+public with sharing class CartItemExtensionSample {
+    public CartItemExtensionSample() {
+
+    }
+}

--- a/commerce/endpoint/cart/CartItemExtensionSample.cls
+++ b/commerce/endpoint/cart/CartItemExtensionSample.cls
@@ -54,16 +54,12 @@ public with sharing class CartItemExtensionSample extends ConnectApi.BaseEndpoin
                     Decimal listPrice = Decimal.valueOf(listPriceStr);
 
                     // Adjust the listPrice based on the currencyIsoCode
-                    switch on currencyCode {
-                        when USD_CURRENCY_ISO_CODE {
-                            listPrice += USD_ADJUSTMENT;
-                        }
-                        when AED_CURRENCY_ISO_CODE {
-                            listPrice += AED_ADJUSTMENT;
-                        }
-                        when else {
-                            listPrice += ADJUSTMENT;
-                        }
+                    if (currencyCode == USD_CURRENCY_ISO_CODE) {
+                        listPrice += USD_ADJUSTMENT;
+                    } else if (currencyCode == AED_CURRENCY_ISO_CODE) {
+                        listPrice += AED_ADJUSTMENT;
+                    } else {
+                        listPrice += ADJUSTMENT;
                     }
 
                     // Set the adjusted listPrice back to the cart item

--- a/commerce/endpoint/cart/CartItemExtensionSample.cls-meta.xml
+++ b/commerce/endpoint/cart/CartItemExtensionSample.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/commerce/endpoint/cart/CartItemExtensionSample.cls-meta.xml
+++ b/commerce/endpoint/cart/CartItemExtensionSample.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/commerce/endpoint/cart/InvalidFormatException.cls
+++ b/commerce/endpoint/cart/InvalidFormatException.cls
@@ -1,0 +1,4 @@
+/**
+ * Custom exception class for handling invalid format exceptions.
+ */
+public with sharing class InvalidFormatException extends Exception{}

--- a/commerce/endpoint/cart/InvalidFormatException.cls-meta.xml
+++ b/commerce/endpoint/cart/InvalidFormatException.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Sample extension for enforcing quantity constraints on a cart item while adding an item to the cart.
This corresponds to the endpoint /commerce/webstores/${webstoreId}/carts/${activeCartOrId}/cart-items
and is identified by the EPN Commerce_Endpoint_Cart_ItemCollection for registration/mapping.

Sample extension for updating the listPrice of a cart item based on the currencyIsoCode during edit operations.
This corresponds to the endpoint /commerce/webstores/${webstoreId}/carts/${activeCartOrId}/cart-items/${cartItemId}
and is identified by the EPN Commerce_Endpoint_Cart_Item for registration/mapping.