### PR TITLE
@W-17689078 - Update Sample CCA Orchestrator to match the default CCA Orchestrator

### DIFF
--- a/commerce/domain/orchestrators/classes/CartCalculateSample.cls
+++ b/commerce/domain/orchestrators/classes/CartCalculateSample.cls
@@ -31,12 +31,37 @@ global class CartCalculateSample extends CartExtension.CartCalculate {
         // Use BuyerActions to decide which calculators to invoke
         CartExtension.BuyerActions buyerActions = request.getBuyerActions();
         boolean isCouponAppliedInCheckout = isCouponAppliedInCheckout(buyerActions, cart);
-        boolean runPricing = buyerActions.isRecalculationRequested() || buyerActions.isCheckoutStarted() || buyerActions.isCartItemChanged();
-        boolean runPromotions = buyerActions.isRecalculationRequested() || buyerActions.isCheckoutStarted() || buyerActions.isCouponChanged() || buyerActions.isCartItemChanged();
-        boolean runInventory = isRecalculationRequestedInCheckout(buyerActions, cart) || buyerActions.isCheckoutStarted();
-        boolean runShipping = isRecalculationRequestedInCheckout(buyerActions, cart) || buyerActions.isDeliveryGroupChanged() || isCouponAppliedInCheckout;
-        boolean runPostShipping = isRecalculationRequestedInCheckout(buyerActions, cart) || buyerActions.isDeliveryGroupChanged() || buyerActions.isDeliveryMethodSelected() || isCouponAppliedInCheckout;
-        boolean runTaxes = isRecalculationRequestedInCheckout(buyerActions, cart) || buyerActions.isDeliveryGroupChanged() || buyerActions.isDeliveryMethodSelected() || isCouponAppliedInCheckout;
+
+        boolean runPricing = buyerActions.isRecalculationRequested() ||
+                            buyerActions.isCheckoutStarted() ||
+                            buyerActions.isCartItemChanged();
+
+        boolean runPromotions = buyerActions.isRecalculationRequested() ||
+                                buyerActions.isCheckoutStarted() ||
+                                buyerActions.isCouponChanged() ||
+                                buyerActions.isCartItemChanged() ||
+                                isCouponAppliedInCheckout;
+
+        boolean runInventory = isRecalculationRequestedInCheckout(buyerActions, cart) ||
+                                buyerActions.isCheckoutStarted() ||
+                                (buyerActions.isCartItemChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus());
+
+        boolean runShipping =  buyerActions.isEvaluateShippingRequested() ||
+                                isRecalculationRequestedInCheckout(buyerActions, cart) && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                                isCouponAppliedInCheckout ||
+                                (buyerActions.isDeliveryGroupChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus());
+
+        boolean runPostShipping = buyerActions.isEvaluateShippingRequested() ||
+                                    (isRecalculationRequestedInCheckout(buyerActions, cart) && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                                    (buyerActions.isDeliveryGroupChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                                    (buyerActions.isDeliveryMethodSelected() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                                    isCouponAppliedInCheckout;
+
+        boolean runTaxes = buyerActions.isEvaluateTaxesRequested() ||
+                            (isRecalculationRequestedInCheckout(buyerActions, cart) && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                            (buyerActions.isDeliveryGroupChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                            (buyerActions.isDeliveryMethodSelected() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                            isCouponAppliedInCheckout;
 
         // OptionalBuyerActionDetails can be used to optimize the various calculators that are invoked
         CartExtension.CartCalculateCalculatorRequest calculatorRequest = new CartExtension.CartCalculateCalculatorRequest(cart, request.getOptionalBuyerActionDetails());

--- a/commerce/domain/orchestrators/classes/CartCalculateSample.cls
+++ b/commerce/domain/orchestrators/classes/CartCalculateSample.cls
@@ -47,7 +47,7 @@ global class CartCalculateSample extends CartExtension.CartCalculate {
                                 (buyerActions.isCartItemChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus());
 
         boolean runShipping =  buyerActions.isEvaluateShippingRequested() ||
-                                isRecalculationRequestedInCheckout(buyerActions, cart) && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
+                                (isRecalculationRequestedInCheckout(buyerActions, cart) && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
                                 isCouponAppliedInCheckout ||
                                 (buyerActions.isDeliveryGroupChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus());
 
@@ -62,6 +62,7 @@ global class CartCalculateSample extends CartExtension.CartCalculate {
                             (buyerActions.isDeliveryGroupChanged() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
                             (buyerActions.isDeliveryMethodSelected() && CartExtension.CartStatusEnum.CHECKOUT == cart.getStatus()) ||
                             isCouponAppliedInCheckout;
+
 
         // OptionalBuyerActionDetails can be used to optimize the various calculators that are invoked
         CartExtension.CartCalculateCalculatorRequest calculatorRequest = new CartExtension.CartCalculateCalculatorRequest(cart, request.getOptionalBuyerActionDetails());

--- a/commerce/domain/orchestrators/classes/CartCalculateSampleUnitTest.cls
+++ b/commerce/domain/orchestrators/classes/CartCalculateSampleUnitTest.cls
@@ -38,6 +38,25 @@ global class CartCalculateSampleUnitTest {
         assertExpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED});
         assertUnexpectedCalculations(cart, new List<String>{INVENTORY_CHECKED, SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
     }
+    
+        @IsTest
+    public static void shouldRunPricingPromotionsInventoryWhenBuyerAddsToCartInCheckoutState() {
+        // Arrange Cart
+        CartExtension.Cart cart = arrangeCart('Checkout');
+
+        // Arrange BuyerActions and BuyerActionDetails as if the Buyer has added an item to cart
+        CartExtension.BuyerActionsMock buyerActions = getBuyerActionsForAddToCart(cart);
+        CartExtension.BuyerActionDetails buyerActionDetails = getBuyerActionDetailsForAddToCart(cart.getCartItems().get(0));
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = CartExtension.OptionalBuyerActionDetails.of(buyerActionDetails);
+
+        // Act
+        act(new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails));
+
+        // Assert
+        assertNoCartValidationOutputs(cart);
+        assertExpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED, INVENTORY_CHECKED});
+        assertUnexpectedCalculations(cart, new List<String>{SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
+    }
 
     @IsTest
     public static void shouldRunPricingAndPromotionsWhenBuyerRemovesItemToCart() {
@@ -56,6 +75,25 @@ global class CartCalculateSampleUnitTest {
         assertNoCartValidationOutputs(cart);
         assertExpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED});
         assertUnexpectedCalculations(cart, new List<String>{INVENTORY_CHECKED, SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
+    }
+    
+    @IsTest
+    public static void shouldRunPricingPromotionsInventoryWhenBuyerRemovesItemToCartInCheckoutState() {
+        // Arrange Cart
+        CartExtension.Cart cart = arrangeCart('Checkout');
+
+        // Arrange BuyerActions and BuyerActionDetails as if the Buyer has added an item to cart
+        CartExtension.BuyerActionsMock buyerActions = getBuyerActionsForDeleteFromCart(cart);
+        CartExtension.BuyerActionDetails buyerActionDetails = getBuyerActionDetailsForDeleteFromCart();
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = CartExtension.OptionalBuyerActionDetails.of(buyerActionDetails);
+
+        // Act
+        act(new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails));
+
+        // Assert
+        assertNoCartValidationOutputs(cart);
+        assertExpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED, INVENTORY_CHECKED});
+        assertUnexpectedCalculations(cart, new List<String>{SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
     }
 
     @IsTest
@@ -133,7 +171,6 @@ global class CartCalculateSampleUnitTest {
         assertExpectedCalculations(cart, new List<String>{PROMOTIONS_RECALCULATED, SHIPPING_RECALCULATED, POST_SHIPPING_COMPLETED, TAXES_RECALCULATED});
         assertUnexpectedCalculations(cart, new List<String>{CART_REPRICED, INVENTORY_CHECKED});
 
-
     }
 
     @IsTest
@@ -177,7 +214,7 @@ global class CartCalculateSampleUnitTest {
     @IsTest
     public static void shouldRunPricingPromotionsInventoryShippingTaxesWhenRegisteredBuyerStartsCheckoutGivenShippingAddressAvailable() {
         // Arrange Cart
-        CartExtension.Cart cart = arrangeCart();
+        CartExtension.Cart cart = arrangeCart('Checkout');
 
         // Arrange BuyerActions and BuyerActionDetails as if the Buyer has started Checkout
         CartExtension.BuyerActionsMock buyerActions = getBuyerActionsForStartCheckoutForBuyerWithShippingAddress(cart);
@@ -189,13 +226,56 @@ global class CartCalculateSampleUnitTest {
 
         // Assert
         assertNoCartValidationOutputs(cart);
+        
         assertExpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED, INVENTORY_CHECKED, SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
+    }
+    
+    @IsTest
+    public static void shouldRunShippingTaxesWhenCartIsInCheckoutStateGivenShippingAddressAvailable() {
+        // Arrange Cart
+        CartExtension.Cart cart = arrangeCart('Checkout');
+
+        // Arrange BuyerActions and BuyerActionDetails as if the Buyer has started Checkout
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock(cart);
+        buyerActions.setDeliveryGroupChanged(True);
+        CartExtension.BuyerActionDetails buyerActionDetails = getBuyerActionDetailsForStartCheckoutForBuyerWithShippingAddress(cart.getCartDeliveryGroups().get(0));
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = CartExtension.OptionalBuyerActionDetails.of(buyerActionDetails);
+
+        // Act
+        act(new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails));
+
+        // Assert
+        assertNoCartValidationOutputs(cart);
+        
+        assertExpectedCalculations(cart, new List<String>{SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
+        assertUnexpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED, INVENTORY_CHECKED});
+    }
+    
+    @IsTest
+    public static void shouldRunNoCalculatorWhenCartIsInActiveStateGivenAndDeliverMethodSelectedAndShippingAddressAvailable() {
+        // Arrange Cart
+        CartExtension.Cart cart = arrangeCart();
+
+        // Arrange BuyerActions and BuyerActionDetails as if the Buyer has started Checkout
+        CartExtension.BuyerActionsMock buyerActions = new CartExtension.BuyerActionsMock(cart);
+        buyerActions.setDeliveryGroupChanged(True);
+        buyerActions.setDeliveryMethodSelected(True);
+        CartExtension.BuyerActionDetails buyerActionDetails = getBuyerActionDetailsForStartCheckoutForBuyerWithShippingAddress(cart.getCartDeliveryGroups().get(0));
+        CartExtension.OptionalBuyerActionDetails optionalBuyerActionDetails = CartExtension.OptionalBuyerActionDetails.of(buyerActionDetails);
+
+        // Act
+        act(new CartExtension.CartCalculateOrchestratorRequest(cart, buyerActions, optionalBuyerActionDetails));
+
+        // Assert
+        assertNoCartValidationOutputs(cart);
+        
+        assertUnexpectedCalculations(cart, new List<String>{CART_REPRICED, PROMOTIONS_RECALCULATED, INVENTORY_CHECKED, SHIPPING_RECALCULATED, TAXES_RECALCULATED, POST_SHIPPING_COMPLETED});
     }
 
     @IsTest
     public static void shouldRunShippingTaxesAndPostShippingWhenBuyerUpdatesShippingAddress() {
         // Arrange Cart
-        CartExtension.Cart cart = arrangeCart();
+        CartExtension.Cart cart = arrangeCart('Checkout');
 
         // Arrange BuyerActions and BuyerActionDetails as if the Buyer has updated their shipping address
         CartExtension.BuyerActionsMock buyerActions = getBuyerActionsForUpdateCheckoutWithShippingAddress(cart);
@@ -214,7 +294,7 @@ global class CartCalculateSampleUnitTest {
     @IsTest
     public static void shouldRunPostShippingAndTaxesWhenBuyerSelectsDeliveryMethod() {
         // Arrange Cart
-        CartExtension.Cart cart = arrangeCart();
+        CartExtension.Cart cart = arrangeCart('Checkout');
 
         // Arrange BuyerActions and BuyerActionDetails as if the Buyer selected a delivery method
         CartExtension.BuyerActionsMock buyerActions = getBuyerActionsForUpdateCheckoutWithSelectedDeliveryMethod(cart);


### PR DESCRIPTION
The Sample CCA Orchestrator has became obsolete and does not match with the changes in default  CCA Orchestrator.
Customers refer to this sample, hence its important keep this sample up to date with default CCA Orchestrator, because internally we test our services based off and the default CCA Orchestrator. So we know default CCA Orchestrator is most compatible with the other code changes we release.

![Screenshot 2025-02-04 at 3 38 02 PM](https://github.com/user-attachments/assets/014bd0f9-09fd-4c41-a07f-670b3664560d)
